### PR TITLE
chore(root): move to TypeScript 3.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "workspaces": [
     "packages/*"
   ],
+  "engines": {
+    "node": ">=10.9.0 <13.0.0",
+    "yarn": ">=1.21.1 <2"
+  },
   "scripts": {
     "---------------- NPM BINARY WRAPPERS ----------------": "",
     "lerna": "lerna",
@@ -44,7 +48,7 @@
     "tsconfig-paths": "^3.8.0",
     "tslint": "^5.13.1",
     "typemoq": "^2.1.0",
-    "typescript": "^3.6.3",
+    "typescript": "~3.5.3",
     "typescript-tslint-plugin": "^0.5.0",
     "webpack-config-utils": "^2.3.1"
   },

--- a/packages/bus/src/public_api.ts
+++ b/packages/bus/src/public_api.ts
@@ -13,8 +13,6 @@ export { BusError } from './errors/bus.error';
 
 export { Handler } from './decorator/handler';
 
-/* Class Map */
-
 // Lookup
 export { HandlerLookupInterface } from './message-handler/message-mapper/handler-lookup/handler-lookup.interface';
 
@@ -33,8 +31,6 @@ export { FunctionConstructorMessageTypeExtractor } from './message-handler/messa
 // Message mapper
 export { MessageMapperInterface } from './message-handler/message-mapper/message-mapper.interface';
 export { MessageMapper } from './message-handler/message-mapper/message.mapper';
-
-/* End Class Map */
 
 // Message Handler
 export { MessageHandlerMiddleware } from './message-handler/message-handler.middleware';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8337,10 +8337,10 @@ typescript-tslint-plugin@^0.5.0:
     mock-require "^3.0.3"
     vscode-languageserver "^5.2.1"
 
-typescript@^3.6.3:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.7.4"


### PR DESCRIPTION
In order to make the library compatible with the frameworks like Angular we have to downgrade TS to
3.5.x

fix #12