### PR TITLE
feat(bus): allow to use name extractor for messages

### DIFF
--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -34,7 +34,7 @@
     "rollup": "rollup -c ../../compile/rollup.config.js --environment NODE_ENV:production --environment PKG:bus",
     "compile": "yarn build && yarn rollup",
     "---------------- TESTING ----------------": "",
-    "test": "nyc ../../node_modules/.bin/_mocha --opts tests/mocha.opts 'tests/**/*.tests.ts'"
+    "test": "nyc ../../node_modules/.bin/_mocha 'tests/**/*.tests.ts'"
   },
   "bugs": {
     "url": "https://github.com/tafax/layerr/issues"

--- a/packages/bus/src/message-handler/message-mapper/extractor/function-constructor.message-type-extractor.ts
+++ b/packages/bus/src/message-handler/message-mapper/extractor/function-constructor.message-type-extractor.ts
@@ -10,7 +10,7 @@ export class FunctionConstructorMessageTypeExtractor implements MessageTypeExtra
   /**
    * @inheritDoc
    */
-  extract(message: any): Function {
+  extract(message: any): Function | string {
     return (message as Object).constructor;
   }
 

--- a/packages/bus/src/message-handler/message-mapper/extractor/identity.message-type-extractor.ts
+++ b/packages/bus/src/message-handler/message-mapper/extractor/identity.message-type-extractor.ts
@@ -10,7 +10,7 @@ export class IdentityMessageTypeExtractor implements MessageTypeExtractorInterfa
   /**
    * @inheritDoc
    */
-  extract(message: any): Function {
+  extract(message: any): Function | string {
     return message;
   }
 

--- a/packages/bus/src/message-handler/message-mapper/extractor/message-type-extractor.interface.ts
+++ b/packages/bus/src/message-handler/message-mapper/extractor/message-type-extractor.interface.ts
@@ -1,9 +1,12 @@
 
+/**
+ * Defines the interface to describe the extractor for messages.
+ */
 export interface MessageTypeExtractorInterface {
 
   /**
    * Resolve the unique name of a message, e.g. the full class name.
    */
-  extract(message: any): Function;
+  extract(message: any): Function | string;
 
 }

--- a/packages/bus/src/message-handler/message-mapper/extractor/name.message-type-extractor.ts
+++ b/packages/bus/src/message-handler/message-mapper/extractor/name.message-type-extractor.ts
@@ -1,0 +1,23 @@
+
+import { ClassType } from "@layerr/core";
+import { MessageTypeExtractorInterface } from './message-type-extractor.interface';
+import { BusError } from "../../../errors/bus.error";
+
+/**
+ * Defines an identity extractor that can be used to
+ * return
+ */
+export class NameMessageTypeExtractor implements MessageTypeExtractorInterface {
+
+  /**
+   * @inheritDoc
+   */
+  extract(message: any): Function | string {
+    if (!(<ClassType<any>>message).name) {
+      throw new BusError(`Unable to find the property 'name' in message: ${message}`);
+    }
+
+    return (<ClassType<any>>message).name;
+  }
+
+}

--- a/packages/bus/tests/fixtures/class-handlers/evil-command-class-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/class-handlers/evil-command-class-handler-for-test.ts
@@ -1,9 +1,9 @@
 
 import { throwError } from 'rxjs';
-import { EvilCommandForTest } from './evil-command-for-test';
-import { CustomError } from './custom.error';
+import { EvilCommandForTest } from '../evil-command-for-test';
+import { CustomError } from '../custom.error';
 
-export class EvilCommandHandlerForTest {
+export class EvilCommandClassHandlerForTest {
   handle(command: EvilCommandForTest) {
     command.checkProperty.should.be.eql('alright!');
     return throwError(new CustomError());

--- a/packages/bus/tests/fixtures/class-handlers/evil-query-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/class-handlers/evil-query-handler-for-test.ts
@@ -1,7 +1,7 @@
 
 import { throwError } from 'rxjs';
-import { EvilQueryForTest } from './evil-query-for-test';
-import { CustomError } from './custom.error';
+import { EvilQueryForTest } from '../evil-query-for-test';
+import { CustomError } from '../custom.error';
 
 export class EvilQueryHandlerForTest {
   handle(query: EvilQueryForTest) {

--- a/packages/bus/tests/fixtures/class-handlers/good-command-class-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/class-handlers/good-command-class-handler-for-test.ts
@@ -1,8 +1,8 @@
 
 import { of } from 'rxjs';
-import { GoodCommandForTest } from './good-command-for-test';
+import { GoodCommandForTest } from '../good-command-for-test';
 
-export class GoodCommandHandlerForTest {
+export class GoodCommandClassHandlerForTest {
   handle(command: GoodCommandForTest) {
     command.checkProperty.should.be.eql('alright!');
     return of(undefined);

--- a/packages/bus/tests/fixtures/class-handlers/good-query-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/class-handlers/good-query-handler-for-test.ts
@@ -1,6 +1,6 @@
 
 import { of } from 'rxjs';
-import { GoodQueryForTest } from './good-query-for-test';
+import { GoodQueryForTest } from '../good-query-for-test';
 
 export class GoodQueryHandlerForTest {
   handle(query: GoodQueryForTest) {

--- a/packages/bus/tests/fixtures/evil-command-for-test.ts
+++ b/packages/bus/tests/fixtures/evil-command-for-test.ts
@@ -1,4 +1,10 @@
 
 export class EvilCommandForTest {
+
   checkProperty: string = 'alright!';
+
+  get name(): string {
+    return 'EvilCommandForTest';
+  }
+
 }

--- a/packages/bus/tests/fixtures/good-command-for-test.ts
+++ b/packages/bus/tests/fixtures/good-command-for-test.ts
@@ -1,4 +1,9 @@
 
 export class GoodCommandForTest {
+
   checkProperty: string = 'alright!';
+
+  get name(): string {
+    return 'GoodCommandForTest';
+  }
 }

--- a/packages/bus/tests/fixtures/string-handlers/evil-command-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/string-handlers/evil-command-handler-for-test.ts
@@ -1,0 +1,10 @@
+
+import { throwError } from 'rxjs';
+import { CustomError } from '../custom.error';
+
+export class EvilCommandStringHandlerForTest {
+  handle(command: string) {
+    command.should.be.eql('EvilCommandForTest');
+    return throwError(new CustomError());
+  }
+}

--- a/packages/bus/tests/fixtures/string-handlers/good-command-handler-for-test.ts
+++ b/packages/bus/tests/fixtures/string-handlers/good-command-handler-for-test.ts
@@ -1,0 +1,9 @@
+
+import { of } from 'rxjs';
+
+export class GoodCommandStringHandlerForTest {
+  handle(command: string) {
+    command.should.be.eql('GoodCommandForTest');
+    return of(undefined);
+  }
+}

--- a/packages/bus/tests/integration/query-bus/query-bus.integration.tests.ts
+++ b/packages/bus/tests/integration/query-bus/query-bus.integration.tests.ts
@@ -11,9 +11,9 @@ import {
 } from '../../..';
 import { CustomError } from '../../fixtures/custom.error';
 import { EvilQueryForTest } from '../../fixtures/evil-query-for-test';
-import { EvilQueryHandlerForTest } from '../../fixtures/evil-query-handler-for-test';
+import { EvilQueryHandlerForTest } from '../../fixtures/class-handlers/evil-query-handler-for-test';
 import { GoodQueryForTest } from '../../fixtures/good-query-for-test';
-import { GoodQueryHandlerForTest } from '../../fixtures/good-query-handler-for-test';
+import { GoodQueryHandlerForTest } from '../../fixtures/class-handlers/good-query-handler-for-test';
 
 //@ts-ignore
 @suite class QueryBusIntegrationTests {

--- a/packages/bus/tests/unit/message-handler/mapper/extractor/identity.message-type-extractor.unit.tests.ts
+++ b/packages/bus/tests/unit/message-handler/mapper/extractor/identity.message-type-extractor.unit.tests.ts
@@ -1,0 +1,21 @@
+
+import { suite, test } from '@layerr/test';
+import { IdentityMessageTypeExtractor } from '../../../../../src/message-handler/message-mapper/extractor/identity.message-type-extractor';
+
+//@ts-ignore
+@suite class IdentityMessageTypeExtractorUnitTests {
+
+  private extractor: IdentityMessageTypeExtractor;
+
+  before() {
+    this.extractor = new IdentityMessageTypeExtractor();
+  }
+
+  @test 'should extract the identity of an object'() {
+    class TestClassToExtract {}
+    const message = new TestClassToExtract();
+    this.extractor.extract(message).should.be.eql(message);
+    this.extractor.extract('message').should.be.eql('message');
+  }
+
+}

--- a/packages/bus/tests/unit/message-handler/mapper/extractor/name.message-type-extractor.unit.tests.ts
+++ b/packages/bus/tests/unit/message-handler/mapper/extractor/name.message-type-extractor.unit.tests.ts
@@ -1,0 +1,29 @@
+
+import { suite, test } from '@layerr/test';
+import { NameMessageTypeExtractor } from "../../../../../src/message-handler/message-mapper/extractor/name.message-type-extractor";
+import {BusError} from "../../../../../src/errors/bus.error";
+
+//@ts-ignore
+@suite class NameMessageTypeExtractorUnitTests {
+
+  private extractor: NameMessageTypeExtractor;
+
+  before() {
+    this.extractor = new NameMessageTypeExtractor();
+  }
+
+  @test 'should extract the correct name of an object'() {
+    class TestClassToExtract {
+      get name() { return 'name'; }
+    }
+    this.extractor.extract(new TestClassToExtract()).should.be.eql('name');
+  }
+
+  @test 'should throw an exception if the name is not defined'() {
+    class TestClassToExtract {}
+    (() => {
+      this.extractor.extract(new TestClassToExtract())
+    }).should.throw(BusError);
+  }
+
+}


### PR DESCRIPTION
Provide the ability to use a property that specifies the message name when you use a class as
message

fix #26