### PR TITLE
fix(bus): move the RxJs to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.0.0",
     "rollup-plugin-uglify": "^6.0.2",
+    "rxjs": "~6.5.5",
     "semantic-release": "15.9.x",
     "semantic-release-monorepo": "^6.1.1",
     "shx": "^0.3.2",

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -41,8 +41,10 @@
   },
   "dependencies": {
     "@layerr/core": "*",
-    "rxjs": "^6.5.3",
     "ts-polyfill": "^3.5.3"
+  },
+  "peerDependencies": {
+    "rxjs": "~6.5.5"
   },
   "nyc": {
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7590,6 +7590,13 @@ rxjs@^6.4.0, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@~6.5.5:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"


### PR DESCRIPTION
Just move back the RxJs as peer dependency to avoid incompatibility for the projects that already
have it as production dependency

fix #37