### PR TITLE
feat(http): add a new middleware to handle an error response

### DIFF
--- a/packages/http/src/error/http-bus.error-type.ts
+++ b/packages/http/src/error/http-bus.error-type.ts
@@ -1,0 +1,11 @@
+
+export enum HttpBusErrorType {
+  UNKNOWN,
+  INTERNAL,
+  TIMEOUT,
+  UNAUTHENTICATED,
+  FORBIDDEN,
+  MALFORMED,
+  NOT_FOUND,
+  UNEXPECTED
+}

--- a/packages/http/src/error/http-bus.error.ts
+++ b/packages/http/src/error/http-bus.error.ts
@@ -1,0 +1,68 @@
+
+/* istanbul ignore file */
+
+import { RequestInterface } from '../request/request.interface';
+import { HttpBusErrorType } from './http-bus.error-type';
+
+/**
+ * Basic error thrown when an error occurs.
+ */
+export class HttpBusError extends Error {
+
+  constructor(
+    _message: string,
+    private _type: HttpBusErrorType,
+    private _status: number | null,
+    private _statusText: string | null,
+    private _request: RequestInterface | null,
+    private _original: Error | null,
+    private _errorContent: any | null
+  ) {
+    super(_message);
+
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, HttpBusError.prototype);
+  }
+
+  /**
+   * Gets the type of the error.
+   */
+  get type(): HttpBusErrorType {
+    return this._type;
+  }
+
+  /**
+   * Gets the status code.
+   */
+  get status(): number | null {
+    return this._status;
+  }
+
+  /**
+   * Gets the status text.
+   */
+  get statusText(): string | null {
+    return this._statusText;
+  }
+
+  /**
+   * Gets the content of the error.
+   */
+  get errorContent(): any | null {
+    return this._errorContent;
+  }
+
+  /**
+   * Gets the request.
+   */
+  get request(): RequestInterface | null {
+    return this._request;
+  }
+
+  /**
+   * Gets the original error.
+   */
+  get original(): Error | null {
+    return this._original;
+  }
+}

--- a/packages/http/src/middleware/error-execution.bus-middleware.ts
+++ b/packages/http/src/middleware/error-execution.bus-middleware.ts
@@ -1,0 +1,97 @@
+
+import { MessageBusMiddlewareInterface } from '@layerr/bus';
+import { LoggerInterface } from '@layerr/core';
+import { Observable, TimeoutError, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { HttpBusError } from '../error/http-bus.error';
+import { HttpBusErrorType } from '../error/http-bus.error-type';
+import { HttpExecution } from '../http-execution';
+import { ErrorRemoteResponse } from '../response/error-remote-response';
+
+/**
+ * Defines the error middleware to handle the error in the execution bus.
+ */
+export class ErrorExecutionBusMiddleware implements MessageBusMiddlewareInterface {
+
+  constructor(
+    private _logger: LoggerInterface
+  ) {}
+
+  /**
+   * @inheritDoc
+   */
+  handle(message: HttpExecution, next: (message: HttpExecution) => Observable<any>): Observable<any> {
+    return next(message)
+      .pipe(
+        catchError((error: Error) => {
+
+          let rethrownError = error;
+
+          if (error instanceof TimeoutError) {
+            this._logger.error(`TimeoutError: ${error.message} - RemoteCall: ${message.request.path}`);
+            rethrownError = new HttpBusError(
+              error.message,
+              HttpBusErrorType.TIMEOUT,
+              -1,
+              'Timeout',
+              message.request,
+              null,
+              null
+            );
+          }
+
+          if (error instanceof ErrorRemoteResponse) {
+
+            const isUnknown = !error.status || error.status === 0;
+
+            if (isUnknown) {
+              this._logger.error(`Unknown error: ${error.message} - RemoteCall: ${message.request.path}`);
+              rethrownError = new HttpBusError(
+                `No status code - Unknown error [ ${error.statusText} - ${error.message} ]`,
+                HttpBusErrorType.UNKNOWN,
+                0,
+                error.statusText,
+                message.request,
+                error,
+                null
+              );
+            } else {
+
+              let type;
+              switch (error.status) {
+                case 400:
+                  type = HttpBusErrorType.MALFORMED;
+                  break;
+                case 401:
+                  type = HttpBusErrorType.UNAUTHENTICATED;
+                  break;
+                case 403:
+                  type = HttpBusErrorType.FORBIDDEN;
+                  break;
+                case 404:
+                  type = HttpBusErrorType.NOT_FOUND;
+                  break;
+                default:
+                  type = HttpBusErrorType.UNEXPECTED;
+              }
+
+              this._logger.error(`Error: ${error.status} ${error.statusText} ${error.message} - RemoteCall: ${message.request.path}`);
+              rethrownError = new HttpBusError(
+                `${error.statusText ? error.statusText : 'Generic error'} - ${error.message}`,
+                type,
+                error.status,
+                error.statusText,
+                message.request,
+                error,
+                // The error content.
+                error.body
+              );
+            }
+          }
+
+          return throwError(rethrownError);
+        })
+      );
+  }
+
+}

--- a/packages/http/src/response/error-remote-response.ts
+++ b/packages/http/src/response/error-remote-response.ts
@@ -24,7 +24,7 @@ export class ErrorRemoteResponse<T> extends RemoteResponse<T> implements Error {
 
   constructor(
     message: string,
-    error: any | null,
+    error: Error | null,
     body: T | null,
     headers: HttpHeaders,
     status: number,

--- a/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
@@ -1,0 +1,326 @@
+
+import { LoggerInterface } from '@layerr/core';
+import { suite, test, IMock, Mock, Times, should } from '@layerr/test';
+import { Observable, throwError, TimeoutError } from 'rxjs';
+import { RequestInterface, HttpHeaders } from '../../..';
+import { HttpBusError } from '../../../src/error/http-bus.error';
+import { HttpBusErrorType } from '../../../src/error/http-bus.error-type';
+import { HttpExecution } from '../../../src/http-execution';
+import { ErrorExecutionBusMiddleware } from '../../../src/middleware/error-execution.bus-middleware';
+import { ErrorRemoteResponse } from '../../../src/response/error-remote-response';
+
+@suite class ErrorExecutionBusMiddlewareUnitTests {
+
+  private middleware: ErrorExecutionBusMiddleware;
+  private loggerMock: IMock<LoggerInterface>;
+
+  before() {
+    this.loggerMock = Mock.ofType<LoggerInterface>();
+    this.middleware = new ErrorExecutionBusMiddleware(this.loggerMock.object);
+  }
+
+  @test 'should create an error for the timeout'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const timeoutError = new TimeoutError();
+    timeoutError.message = 'timeout';
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(timeoutError))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+    )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(timeoutError.message);
+          error.type.should.be.eql(HttpBusErrorType.TIMEOUT);
+          error.status.should.be.eql(-1);
+          error.statusText.should.be.eql('Timeout');
+          error.request.should.be.eql(execution.request);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 400'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      400,
+      '400',
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`400 - ${errorRemoteResponse.message}`);
+          error.type.should.be.eql(HttpBusErrorType.MALFORMED);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          error.statusText.should.be.eql(errorRemoteResponse.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          error.errorContent.should.be.eql(errorRemoteResponse.body);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 401'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      401,
+      '401',
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`401 - ${errorRemoteResponse.message}`);
+          error.type.should.be.eql(HttpBusErrorType.UNAUTHENTICATED);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          error.statusText.should.be.eql(errorRemoteResponse.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          error.errorContent.should.be.eql(errorRemoteResponse.body);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 403'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      403,
+      '403',
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`403 - ${errorRemoteResponse.message}`);
+          error.type.should.be.eql(HttpBusErrorType.FORBIDDEN);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          error.statusText.should.be.eql(errorRemoteResponse.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          error.errorContent.should.be.eql(errorRemoteResponse.body);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 404'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      404,
+      '404',
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`404 - ${errorRemoteResponse.message}`);
+          error.type.should.be.eql(HttpBusErrorType.NOT_FOUND);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          error.statusText.should.be.eql(errorRemoteResponse.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          error.errorContent.should.be.eql(errorRemoteResponse.body);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 500'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      500,
+      null,
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`Generic error - ${errorRemoteResponse.message}`);
+          error.type.should.be.eql(HttpBusErrorType.UNEXPECTED);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          should.not.exist(error.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          error.errorContent.should.be.eql(errorRemoteResponse.body);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+  @test 'should create an error for the error status 0'() {
+
+    const execution = new HttpExecution();
+    execution.request = {} as unknown as RequestInterface;
+
+    const baseError = new Error();
+
+    const errorRemoteResponse = new ErrorRemoteResponse(
+      'message',
+      baseError,
+      {},
+      new HttpHeaders(),
+      0,
+      '0',
+      'url'
+    );
+
+    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    nextMock
+      .setup(x => x(execution))
+      .returns(() => throwError(errorRemoteResponse))
+      .verifiable(Times.once());
+
+    return this.middleware.handle(
+      execution,
+      nextMock.object
+      )
+      .subscribe(
+        () => { throw new Error('it-should-never-called'); },
+        (error: HttpBusError) => {
+          error.should.be.instanceof(HttpBusError);
+
+          error.message.should.be.eql(`No status code - Unknown error [ 0 - ${errorRemoteResponse.message} ]`);
+          error.type.should.be.eql(HttpBusErrorType.UNKNOWN);
+          error.status.should.be.eql(errorRemoteResponse.status);
+          error.statusText.should.be.eql(errorRemoteResponse.statusText);
+          error.request.should.be.eql(execution.request);
+          error.original.should.be.eql(errorRemoteResponse);
+          should.not.exist(error.errorContent);
+
+          nextMock.verifyAll();
+        }
+      );
+  }
+
+}


### PR DESCRIPTION
Adding the middleware to handle the error response and transform it into an error to propage upward.

fix #44