### PR TITLE
feat(http): allows a request to specify a base host

### DIFF
--- a/packages/http/src/middleware/http-backend/decorator/http-backend.decorator-resolver.ts
+++ b/packages/http/src/middleware/http-backend/decorator/http-backend.decorator-resolver.ts
@@ -1,0 +1,18 @@
+
+import { HandlerLookupInterface } from '@layerr/bus';
+import { DecoratorMetadataResolver, ClassType } from '@layerr/core';
+import { RequestInterface } from '../../../request/request.interface';
+import { HttpBackendKeys } from './http-backend.keys';
+
+export class HttpBackendDecoratorResolver<T> implements HandlerLookupInterface {
+
+  private _extractor: DecoratorMetadataResolver = new DecoratorMetadataResolver(HttpBackendKeys.HTTP_BACKEND_OPTION);
+
+  /**
+   * @inheritDoc
+   */
+  getValue(message: ClassType<RequestInterface>): T {
+    return this._extractor.getMetadata(message);
+  }
+
+}

--- a/packages/http/src/middleware/http-backend/decorator/http-backend.keys.ts
+++ b/packages/http/src/middleware/http-backend/decorator/http-backend.keys.ts
@@ -1,0 +1,12 @@
+
+/**
+ * Defines a set of metadata keys to use with decorators.
+ */
+export class HttpBackendKeys {
+
+  /**
+   * The keys used to store the options related to.
+   */
+  static HTTP_BACKEND_OPTION = 'layerr-http:http-backend:options';
+
+}

--- a/packages/http/src/middleware/http-backend/decorator/http-backend.ts
+++ b/packages/http/src/middleware/http-backend/decorator/http-backend.ts
@@ -1,0 +1,5 @@
+
+import { createOptionsDecorator, ClassType } from '@layerr/core';
+import { HttpBackendKeys } from './http-backend.keys';
+
+export const HttpBackend = createOptionsDecorator<string | number, ClassType<any>>(HttpBackendKeys.HTTP_BACKEND_OPTION);

--- a/packages/http/src/middleware/http-backend/http-backend.bus-middleware.ts
+++ b/packages/http/src/middleware/http-backend/http-backend.bus-middleware.ts
@@ -1,0 +1,87 @@
+
+import { MessageBusMiddlewareInterface, MessageTypeExtractorInterface } from '@layerr/bus';
+import { ClassType } from '@layerr/core';
+import { Observable, throwError } from 'rxjs';
+import { HttpLayerrError } from '../../error/http-layerr.error';
+import { HttpLayerrErrorType } from '../../error/http-layerr.error-type';
+import { HttpExecution } from '../../http-execution';
+import { RequestInterface } from '../../request/request.interface';
+import { HttpBackendDecoratorResolver } from './decorator/http-backend.decorator-resolver';
+
+/**
+ * Defines a middleware to decide which is the base host given a request decorated
+ * with a specific backend.
+ */
+export class HttpBackendBusMiddleware<T extends string | number> implements MessageBusMiddlewareInterface {
+
+  /**
+   * The mapping we want to use between the various backend
+   * and the base hosts.
+   *
+   * Example:
+   * enum Backend {
+   *   ADMIN_API,
+   *   SERVICE_API
+   * }
+   *
+   * The mapping will be:
+   * [
+   *  [ Backend.ADMIN_API, 'https://api.admin.com' ],
+   *  [ Backend.SERVICE_API, 'https://api.service.com' ]
+   * ]
+   */
+  private _map: Map<T, string>;
+
+  constructor(
+    mapping: [ T, string ][],
+    private _extractor: MessageTypeExtractorInterface,
+    private _resolver: HttpBackendDecoratorResolver<T>
+  ) {
+    this._map = new Map(mapping);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handle(message: HttpExecution, next: (message: HttpExecution) => Observable<any>): Observable<any> {
+
+    // Gets the identifier based on the request object.
+    const identifier = this._extractor.extract(message.request);
+
+    // Gets the backend key based on the identifier.
+    const httpBackendIdentifier = this._resolver.getValue(identifier as ClassType<RequestInterface>);
+
+    // Reacts if the identifier is present in the mapping.
+    if (!this._map.has(httpBackendIdentifier)) {
+      return throwError(new HttpLayerrError(
+        `Backend key "${httpBackendIdentifier}" doesn't exists.`,
+        HttpLayerrErrorType.INTERNAL,
+        null,
+        null,
+        message.request,
+        null,
+        null
+      ));
+    }
+
+    // Gets the mapping and verify it is not undefined.
+    const baseHost = this._map.get(httpBackendIdentifier);
+    if (!baseHost) {
+      return throwError(new HttpLayerrError(
+        `Backend key "${httpBackendIdentifier}" points to a not valid base host.`,
+        HttpLayerrErrorType.INTERNAL,
+        null,
+        null,
+        message.request,
+        null,
+        null
+      ));
+    }
+
+    // Converts it to a string to make sure it can be used as base host.
+    message.baseHost = `${baseHost}`;
+
+    return next(message);
+  }
+
+}

--- a/packages/http/src/public_api.ts
+++ b/packages/http/src/public_api.ts
@@ -4,9 +4,37 @@ import 'ts-polyfill/lib/es2015-core';
 import 'ts-polyfill/lib/es2015-promise';
 import 'ts-polyfill/lib/es2015-collection';
 
+// Adapter
+export { HttpAdapterInterface } from './adapter/http-adapter.interface';
+
+// Error
+export { HttpLayerrErrorType } from './error/http-layerr.error-type';
+export { HttpLayerrError } from './error/http-layerr.error';
+
+// Middleware
+export { ErrorExecutionBusMiddleware } from './middleware/error-execution.bus-middleware';
+export { RequestExecutionBusMiddleware } from './middleware/request-execution.bus-middleware';
+export { RequestHandlerBusMiddleware } from './middleware/request-handler.bus-middleware';
+export { HttpBackendBusMiddleware } from './middleware/http-backend/http-backend.bus-middleware';
+export { HttpBackend } from './middleware/http-backend/decorator/http-backend';
+
+// Pagination
+export { PaginatedResult } from './pagination/paginated-result';
+export { PaginationInterface } from './pagination/pagination.interface';
+
 // Requests
 export { AbstractRestfulRequest } from './request/abstract-restful.request';
 export { RequestInterface } from './request/request.interface';
+
+// Request handler
+export { RequestHandlerInterface } from './request-handler/request-handler.interface';
+
+// Response
+export { ErrorRemoteResponse } from './response/error-remote-response';
+export { RemoteResponse } from './response/remote-response';
+
+// Service
+export { RequestExecutor } from './service/request-executor';
 
 // Utilities
 export { HttpHeaders } from './utilities/http-headers';

--- a/packages/http/src/utilities/http-headers.ts
+++ b/packages/http/src/utilities/http-headers.ts
@@ -35,7 +35,7 @@ export class HttpHeaders implements Headers {
    * @inheritDoc
    */
   get(name: string): string | null {
-    return this._map.get(name);
+    return this._map.get(name) || null;
   }
 
   /**

--- a/packages/http/src/utilities/http-params.ts
+++ b/packages/http/src/utilities/http-params.ts
@@ -35,7 +35,7 @@ export class HttpParams implements Headers {
    * @inheritDoc
    */
   get(name: string): string | null {
-    return this._map.get(name);
+    return this._map.get(name) || null;
   }
 
   /**

--- a/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
@@ -1,0 +1,143 @@
+
+import { MessageTypeExtractorInterface } from '@layerr/bus';
+import { suite, test, IMock, Mock, Times, should } from '@layerr/test';
+import { of } from 'rxjs';
+import { RequestInterface } from '../../..';
+import { HttpLayerrError } from '../../../src/error/http-layerr.error';
+import { HttpLayerrErrorType } from '../../../src/error/http-layerr.error-type';
+import { HttpExecution } from '../../../src/http-execution';
+import { HttpBackendDecoratorResolver } from '../../../src/middleware/http-backend/decorator/http-backend.decorator-resolver';
+import { HttpBackendBusMiddleware } from '../../../src/middleware/http-backend/http-backend.bus-middleware';
+import { TestRestfulRequest } from '../../fixtures/test.restful-request';
+
+@suite class HttpBackendBusMiddlewareUnitTests {
+
+  private middleware: HttpBackendBusMiddleware<string>;
+  private extractorMock: IMock<MessageTypeExtractorInterface>;
+  private resolverMock: IMock<HttpBackendDecoratorResolver<string>>;
+
+  before() {
+    this.extractorMock = Mock.ofType<MessageTypeExtractorInterface>();
+    this.resolverMock = Mock.ofType<HttpBackendDecoratorResolver<string>>();
+
+    this.middleware = new HttpBackendBusMiddleware(
+      [
+        [ 'ADMIN', 'api.admin' ],
+        [ 'PUBLIC', 'api.public' ],
+        [ 'NULL', null ],
+      ],
+      this.extractorMock.object,
+      this.resolverMock.object
+    );
+  }
+
+  @test 'should resolve the correct base host'(done) {
+
+    const execution = new HttpExecution();
+    execution.request = {} as RequestInterface;
+
+    this.extractorMock
+      .setup(x => x.extract(execution.request))
+      .returns(() => TestRestfulRequest)
+      .verifiable(Times.once());
+
+    this.resolverMock
+      .setup(x => x.getValue(TestRestfulRequest))
+      .returns(() => 'ADMIN')
+      .verifiable(Times.once());
+
+    const next = (message: HttpExecution) => of(message);
+
+    return this.middleware.handle(execution, next)
+      .subscribe(
+        (message: HttpExecution) => {
+
+          message.baseHost.should.be.eql('api.admin');
+
+          this.extractorMock.verifyAll();
+          this.resolverMock.verifyAll();
+
+          done();
+        }
+      );
+  }
+
+  @test 'should throw an exception if the backend key is not defined'(done) {
+
+    const execution = new HttpExecution();
+    execution.request = {} as RequestInterface;
+
+    this.extractorMock
+      .setup(x => x.extract(execution.request))
+      .returns(() => TestRestfulRequest)
+      .verifiable(Times.once());
+
+    this.resolverMock
+      .setup(x => x.getValue(TestRestfulRequest))
+      .returns(() => 'NOT_DEFINED')
+      .verifiable(Times.once());
+
+    const next = (message: HttpExecution) => of(message);
+
+    return this.middleware.handle(execution, next)
+      .subscribe(
+        () => { throw new Error('it-should-not-be-called'); },
+        (error: HttpLayerrError) => {
+
+          error.should.be.instanceof(HttpLayerrError);
+          error.message.should.be.eql('Backend key "NOT_DEFINED" doesn\'t exists.');
+          error.type.should.be.eql(HttpLayerrErrorType.INTERNAL);
+          error.request.should.be.eql(execution.request);
+          should.not.exist(error.status);
+          should.not.exist(error.statusText);
+          should.not.exist(error.original);
+          should.not.exist(error.errorContent);
+
+          this.extractorMock.verifyAll();
+          this.resolverMock.verifyAll();
+
+          done();
+        }
+      );
+  }
+
+  @test 'should throw an exception if the base host is not defined'(done) {
+
+    const execution = new HttpExecution();
+    execution.request = {} as RequestInterface;
+
+    this.extractorMock
+      .setup(x => x.extract(execution.request))
+      .returns(() => TestRestfulRequest)
+      .verifiable(Times.once());
+
+    this.resolverMock
+      .setup(x => x.getValue(TestRestfulRequest))
+      .returns(() => 'NULL')
+      .verifiable(Times.once());
+
+    const next = (message: HttpExecution) => of(message);
+
+    return this.middleware.handle(execution, next)
+      .subscribe(
+        () => { throw new Error('it-should-not-be-called'); },
+        (error: HttpLayerrError) => {
+
+          error.should.be.instanceof(HttpLayerrError);
+          error.message.should.be.eql('Backend key "NULL" points to a not valid base host.');
+          error.type.should.be.eql(HttpLayerrErrorType.INTERNAL);
+          error.request.should.be.eql(execution.request);
+          should.not.exist(error.status);
+          should.not.exist(error.statusText);
+          should.not.exist(error.original);
+          should.not.exist(error.errorContent);
+
+          this.extractorMock.verifyAll();
+          this.resolverMock.verifyAll();
+
+          done();
+        }
+      );
+  }
+
+}


### PR DESCRIPTION
Allows to specify a per request base host, so that any request can potentially triggers a different
api set.

fix #53