### PR TITLE
docs(http): first documentation round for HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ but the libraries it already contains are production ready.
 
 - [x] :bus: Powerful message bus
 
-- [ ] :rocket: Fast and extensible API client
+- [x] :rocket: Fast and extensible API client
 
 - [ ] :scissors: A parser library for JSON
 
@@ -40,6 +40,7 @@ documentations.
 
 * [CORE](https://github.com/tafax/layerr/tree/master/packages/core)
 * [BUS](https://github.com/tafax/layerr/tree/master/packages/bus)
+* [HTTP](https://github.com/tafax/layerr/tree/master/packages/http)
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -2,7 +2,7 @@
 # HTTP
 
 **HttpLayer** is a library to create a request bus layer in your application. You can use
-to create an HTTP client with a powerful and easy to extend way. \
+to create an easy-to-extend and powerful HTTP client. \
 It is also completely configurable using middlewares.
 
 It uses [RxJS](https://github.com/ReactiveX/RxJS) as internal engine. If you are not

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerr/http",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "A powerful library to create an http client layer in your application",
   "author": "Matteo Tafani Alunno <matteo.tafanialunno@gmail.com>",
   "homepage": "https://github.com/tafax/layerr/tree/master/packages/bus#readme",


### PR DESCRIPTION
Just change the documentation for HTTP. It is the first round to improve it.

fix #55