### PR TITLE
fix(http): change the http adapter interface to support base host

### DIFF
--- a/packages/http/src/adapter/http-adapter.interface.ts
+++ b/packages/http/src/adapter/http-adapter.interface.ts
@@ -12,6 +12,6 @@ export interface HttpAdapterInterface {
   /**
    * Executes the call using the specific adapter.
    */
-  execute<T>(remoteCall: RequestInterface): Observable<RemoteResponse<T>>;
+  execute<T>(baseHost: string, remoteCall: RequestInterface): Observable<RemoteResponse<T>>;
 
 }

--- a/packages/http/src/middleware/request-execution.bus-middleware.ts
+++ b/packages/http/src/middleware/request-execution.bus-middleware.ts
@@ -18,7 +18,7 @@ export class RequestExecutionBusMiddleware implements MessageBusMiddlewareInterf
    */
   handle(message: HttpExecution, next: (message: HttpExecution) => Observable<any>): Observable<any> {
     // Starts by streaming the request.
-    let request$ = this._httpAdapter.execute<JsonType>(message.request);
+    let request$ = this._httpAdapter.execute<JsonType>(message.baseHost, message.request);
 
     // TODO: Find a way to test it as unit.
     /* istanbul ignore if */

--- a/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
+++ b/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
@@ -77,7 +77,7 @@ import { TestRestfulRequest } from '../fixtures/test.restful-request';
       .verifiable(Times.once());
 
     this.httpAdapterMock
-      .setup(x => x.execute(It.isAny()))
+      .setup(x => x.execute('baseHost', request))
       .returns(() => of(remoteResponse))
       .verifiable(Times.once());
 
@@ -111,7 +111,7 @@ import { TestRestfulRequest } from '../fixtures/test.restful-request';
       .verifiable(Times.once());
 
     this.httpAdapterMock
-      .setup(x => x.execute(It.isAny()))
+      .setup(x => x.execute('baseHost', request))
       .returns(() => throwError(errorRemoteResponse))
       .verifiable(Times.once());
 

--- a/packages/http/tests/unit/middleware/request-execution.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/request-execution.bus-middleware.unit.tests.ts
@@ -24,6 +24,7 @@ import { HttpHeaders } from '../../../src/utilities/http-headers';
     const remoteCallMock = {} as unknown as RequestInterface;
 
     const execution = new HttpExecution();
+    execution.baseHost = 'baseHost';
     execution.request = remoteCallMock;
     execution.retryAttemptCount = 0;
 
@@ -36,7 +37,7 @@ import { HttpHeaders } from '../../../src/utilities/http-headers';
     );
 
     this.adapterMock
-      .setup(x => x.execute(remoteCallMock))
+      .setup(x => x.execute('baseHost', remoteCallMock))
       .returns(() => of(response))
       .verifiable(Times.once());
 
@@ -60,6 +61,7 @@ import { HttpHeaders } from '../../../src/utilities/http-headers';
     const remoteCallMock = {} as unknown as RequestInterface;
 
     const execution = new HttpExecution();
+    execution.baseHost = 'baseHost';
     execution.request = remoteCallMock;
     execution.retryAttemptCount = 0;
 
@@ -74,7 +76,7 @@ import { HttpHeaders } from '../../../src/utilities/http-headers';
     );
 
     this.adapterMock
-      .setup(x => x.execute(remoteCallMock))
+      .setup(x => x.execute('baseHost', remoteCallMock))
       .returns(() => throwError(errorRemoteResponse))
       .verifiable(Times.once());
 


### PR DESCRIPTION
Adding the base host in the interface of the http adapter

fix #58