### PR TITLE
feat(http): add new method to headers object

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -65,5 +65,6 @@
     "sourceMap": true,
     "instrument": true,
     "report-dir": "./coverage"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/http/src/utilities/http-headers.ts
+++ b/packages/http/src/utilities/http-headers.ts
@@ -7,7 +7,31 @@ export class HttpHeaders implements Headers {
   /**
    * The map to use to store values.
    */
-  private _map: Map<string, string> = new Map();
+  private _map: Map<string, string>;
+
+  constructor(headers?: HttpHeaders | string[][] | Record<string, string>) {
+
+    this._map = new Map();
+
+    if (!headers) {
+      return;
+    }
+
+    if (Array.isArray(headers)) {
+      this._map = new Map(headers as unknown as readonly [ string, string ][]);
+      return;
+    }
+
+    if (headers instanceof HttpHeaders) {
+      headers.forEach(
+        (value: string, key: string) => this._map.set(key, value)
+      );
+      return;
+    }
+
+    const headersInit = headers as Record<string, string>;
+    Object.keys(headersInit).forEach((key: string) => this._map.set(key, (headersInit[key])));
+  }
 
   /**
    * @inheritDoc
@@ -53,6 +77,20 @@ export class HttpHeaders implements Headers {
       (value, key) => callbackfn(value, key, this),
       thisArg
     );
+  }
+
+  /**
+   * Converts the headers into a JSON object.
+   */
+  toObject(): Record<string, string> {
+    let obj = {};
+    for (const key of Array.from(this._map.keys())) {
+      obj = {
+        ...obj,
+        [key]: this._map.get(key)
+      };
+    }
+    return obj;
   }
 
 }

--- a/packages/http/tests/unit/utilities/http-headers.unit.tests.ts
+++ b/packages/http/tests/unit/utilities/http-headers.unit.tests.ts
@@ -1,5 +1,6 @@
 
-import { suite, test } from '@layerr/test';
+
+import { suite, test, should } from '@layerr/test';
 import { HttpHeaders } from '../../../src/utilities/http-headers';
 
 @suite class HttpHeadersUnitTests {
@@ -41,6 +42,64 @@ import { HttpHeaders } from '../../../src/utilities/http-headers';
       },
       this
     );
+  }
+
+  @test 'should return null if the key is not defined'() {
+    should.not.exist(this.headers.get('some'));
+  }
+
+  @test 'should convert the headers into a json object'() {
+    this.headers.append('name1', 'value1');
+    this.headers.append('name2', 'value2');
+    this.headers.append('name3', 'value3');
+    this.headers.toObject().should.be.eql({
+      name1: 'value1',
+      name2: 'value2',
+      name3: 'value3',
+    });
+  }
+
+  @test 'should create a filled header'() {
+
+    const stringHeaders = [
+      [ 'name1', 'value1' ],
+      [ 'name2', 'value2' ],
+      [ 'name3', 'value3' ]
+    ];
+
+    const newHttpHeaders = new HttpHeaders();
+    newHttpHeaders.append('name1', 'value1');
+    newHttpHeaders.append('name2', 'value2');
+    newHttpHeaders.append('name3', 'value3');
+
+    const recordsHeaders = {
+      name1: 'value1',
+      name2: 'value2',
+      name3: 'value3',
+    };
+
+    const httpStringHeaders = new HttpHeaders(stringHeaders);
+    const httpHttpHeaders = new HttpHeaders(newHttpHeaders);
+    const httpRecordsHeaders = new HttpHeaders(recordsHeaders);
+
+    httpStringHeaders.toObject().should.be.eql({
+      name1: 'value1',
+      name2: 'value2',
+      name3: 'value3',
+    });
+
+    httpHttpHeaders.toObject().should.be.eql({
+      name1: 'value1',
+      name2: 'value2',
+      name3: 'value3',
+    });
+
+    httpRecordsHeaders.toObject().should.be.eql({
+      name1: 'value1',
+      name2: 'value2',
+      name3: 'value3',
+    });
+
   }
 
 }

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "declarationDir": "./dist/types",
     "outDir": "./dist/esm5",
-    "strict": true
+    "strict": true,
+    "downlevelIteration": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
We need to introduce new method in the headers object to allow it to convert itself into an object.
This will help the consumer to convert the headers object to be processed into the call.

fix #60