### PR TITLE
feat(http): add new methods in query object

### DIFF
--- a/packages/http/src/utilities/http-params.ts
+++ b/packages/http/src/utilities/http-params.ts
@@ -2,7 +2,7 @@
 /**
  * Defines the HTTP params class.
  */
-export class HttpParams implements Headers {
+export class HttpParams implements URLSearchParams {
 
   /**
    * The map to use to store values.
@@ -13,7 +13,7 @@ export class HttpParams implements Headers {
    * @inheritDoc
    */
   append(name: string, value: string): void {
-    // TODO: Implements a real append.
+    // Right now, we just support a single value for a key.
     this._map.set(name, value);
   }
 
@@ -41,18 +41,56 @@ export class HttpParams implements Headers {
   /**
    * @inheritDoc
    */
+  getAll(name: string): string[] {
+    if (!this._map.has(name)) {
+      return [];
+    }
+    return [ this._map.get(name)! ];
+  }
+
+  /**
+   * @inheritDoc
+   */
   set(name: string, value: string): void {
+    // We don't set undefined values.
+    if (!value) {
+      return;
+    }
     this._map.set(name, value);
   }
 
   /**
    * @inheritDoc
    */
-  forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void {
+  /* istanbul ignore next */
+  sort(): void {
+    // Not implemented!
+  }
+
+  /**
+   * @inheritDoc
+   */
+  forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void {
     this._map.forEach(
       (value, key) => callbackfn(value, key, this),
       thisArg
     );
+  }
+
+  /**
+   * Tells if the params are empty or not.
+   */
+  isEmpty(): boolean {
+    return Array.from(this._map.keys()).length === 0;
+  }
+
+  /**
+   * Converts the params into a query string.
+   */
+  toString(): string {
+    return Array.from(this._map.keys())
+      .map((key: string) => encodeURIComponent(key) + '=' + encodeURIComponent(this._map.get(key)!))
+      .join('&');
   }
 
 }

--- a/packages/http/tests/unit/utilities/http-params.unit.tests.ts
+++ b/packages/http/tests/unit/utilities/http-params.unit.tests.ts
@@ -1,5 +1,5 @@
 
-import { suite, test } from '@layerr/test';
+import { suite, test, should } from '@layerr/test';
 import { HttpParams } from '../../../src/utilities/http-params';
 
 @suite class HttpParamsUnitTests {
@@ -18,6 +18,9 @@ import { HttpParams } from '../../../src/utilities/http-params';
   @test 'should set a new value'() {
     this.params.set('name', 'value');
     this.params.get('name').should.be.eql('value');
+
+    this.params.set('name1', undefined);
+    should.not.exist(this.params.get('name1'));
   }
 
   @test 'should has a value'() {
@@ -41,6 +44,34 @@ import { HttpParams } from '../../../src/utilities/http-params';
       },
       this
     );
+  }
+
+  @test 'should get all the values for a specific key'() {
+    this.params.set('name', 'value');
+    this.params.getAll('name').should.be.eql([ 'value' ]);
+
+    this.params.getAll('nokey').should.be.eql([]);
+  }
+
+  @test 'should return null if the key is not defined'() {
+    should.not.exist(this.params.get('some'));
+  }
+
+  @test 'should return true if it is empty, false otherwise'() {
+    this.params.isEmpty().should.be.true;
+
+    this.params.set('name', 'value');
+
+    this.params.isEmpty().should.be.false;
+  }
+
+  @test 'should return the correct query string'() {
+    this.params.set('name', 'value');
+    this.params.set('name?-', 'value value');
+
+    const query = this.params.toString();
+    query.should.be.eql('name=value&name%3F-=value%20value');
+
   }
 
 }


### PR DESCRIPTION
Adding new methods to the http params object in order to match the common needs for query objects.

fix #57