### PR TITLE
feat(http): make the request immutable

### DIFF
--- a/packages/http/src/http-execution.ts
+++ b/packages/http/src/http-execution.ts
@@ -6,36 +6,105 @@ import { RemoteResponse } from './response/remote-response';
 /**
  * The http execution object that describes the run.
  */
-export class HttpExecution {
+export class HttpExecution<T> {
 
   /**
    * The request to execute.
    */
-  request!: RequestInterface;
+  readonly request: RequestInterface;
 
   /**
    * The response we got.
    */
-  response!: RemoteResponse<JsonType>;
+  readonly response?: RemoteResponse<JsonType>;
+
+  /**
+   * This is the parsed version of the response body.
+   */
+  readonly content?: T;
 
   /**
    * The base host if we want to override it.
    */
-  baseHost!: string;
+  readonly baseHost: string;
 
   /**
    * The retry attempt if we want to override it.
    */
-  retryAttemptCount!: number | null;
+  readonly retryAttemptCount: number | null;
 
   /**
    * The retry delay if we want to override it.
    */
-  retryDelay!: number;
+  readonly retryDelay: number;
 
   /**
    * The timeout if we want to override it.
    */
-  timeout!: number;
+  readonly timeout: number;
+
+  constructor(init: {
+    request: RequestInterface;
+    baseHost: string;
+    retryAttemptCount: number | null;
+    retryDelay: number;
+    timeout: number;
+    response?: RemoteResponse<JsonType>;
+    content?: T;
+  }) {
+    this.request = init.request;
+    this.baseHost = init.baseHost;
+    this.retryAttemptCount = init.retryAttemptCount;
+    this.retryDelay = init.retryDelay;
+    this.timeout = init.timeout;
+    this.response = init.response || undefined;
+    this.content = init.content || undefined;
+  }
+
+  /**
+   * Returns true if the response is set.
+   */
+  hasResponse(): boolean {
+    return !!this.response;
+  }
+
+  /**
+   * Returns true if the response is set.
+   */
+  hasContent(): boolean {
+    return !!this.content;
+  }
+
+  /**
+   * Clones this object to make it immutable.
+   */
+  clone(update?: {
+    baseHost?: string;
+    response?: RemoteResponse<JsonType>;
+    content?: T | null;
+  }): HttpExecution<T> {
+
+    if (!update) {
+      return new HttpExecution<T>({
+        request: this.request,
+        baseHost: this.baseHost,
+        retryAttemptCount: this.retryAttemptCount,
+        retryDelay: this.retryDelay,
+        timeout: this.timeout,
+        response: this.response,
+        content: this.content
+      })
+    }
+
+    return new HttpExecution<T>({
+      request: this.request,
+      baseHost: update.baseHost || this.baseHost,
+      retryAttemptCount: this.retryAttemptCount,
+      retryDelay: this.retryDelay,
+      timeout: this.timeout,
+      response: update.response || this.response,
+      content: update.content || this.content
+    });
+  }
 
 }

--- a/packages/http/src/middleware/error-execution.bus-middleware.ts
+++ b/packages/http/src/middleware/error-execution.bus-middleware.ts
@@ -20,7 +20,7 @@ export class ErrorExecutionBusMiddleware implements MessageBusMiddlewareInterfac
   /**
    * @inheritDoc
    */
-  handle(message: HttpExecution, next: (message: HttpExecution) => Observable<any>): Observable<any> {
+  handle<T>(message: HttpExecution<T>, next: (message: HttpExecution<T>) => Observable<any>): Observable<any> {
     return next(message)
       .pipe(
         catchError((error: Error) => {

--- a/packages/http/src/middleware/http-backend/http-backend.bus-middleware.ts
+++ b/packages/http/src/middleware/http-backend/http-backend.bus-middleware.ts
@@ -43,7 +43,7 @@ export class HttpBackendBusMiddleware<T extends string | number> implements Mess
   /**
    * @inheritDoc
    */
-  handle(message: HttpExecution, next: (message: HttpExecution) => Observable<any>): Observable<any> {
+  handle<T>(message: HttpExecution<T>, next: (message: HttpExecution<T>) => Observable<any>): Observable<any> {
 
     // Gets the identifier based on the request object.
     const identifier = this._extractor.extract(message.request);
@@ -79,9 +79,7 @@ export class HttpBackendBusMiddleware<T extends string | number> implements Mess
     }
 
     // Converts it to a string to make sure it can be used as base host.
-    message.baseHost = `${baseHost}`;
-
-    return next(message);
+    return next(message.clone({ baseHost: `${baseHost}` }));
   }
 
 }

--- a/packages/http/src/public_api.ts
+++ b/packages/http/src/public_api.ts
@@ -23,7 +23,7 @@ export { PaginatedResult } from './pagination/paginated-result';
 export { PaginationInterface } from './pagination/pagination.interface';
 
 // Requests
-export { AbstractRequest, RequestInit } from './request/abstract.request';
+export { AbstractRequest } from './request/abstract.request';
 export { RequestInterface } from './request/request.interface';
 
 // Request handler

--- a/packages/http/src/request-handler/request-handler.interface.ts
+++ b/packages/http/src/request-handler/request-handler.interface.ts
@@ -13,6 +13,6 @@ export interface RequestHandlerInterface {
   /**
    * Handles a specific remote call.
    */
-  handle(remoteCall: RequestInterface, response: RemoteResponse<JsonType>): Observable<RemoteResponse<JsonType>>;
+  handle(remoteCall: RequestInterface, response: RemoteResponse<JsonType>): Observable<any>;
 
 }

--- a/packages/http/src/request/abstract.request.ts
+++ b/packages/http/src/request/abstract.request.ts
@@ -4,24 +4,13 @@ import { HttpHeaders } from '../utilities/http-headers';
 import { HttpMethod } from '../utilities/http-method';
 import { HttpParams } from '../utilities/http-params';
 import { HttpResponseContent } from '../utilities/http-response-content';
-import { CloneableInterface, RequestUpdate } from './cloneable.interface';
 import { RequestInterface } from './request.interface';
-
-export interface RequestInit {
-  path: string;
-  version: string | null;
-  method?: HttpMethod;
-  withCredentials?: boolean;
-  responseType?: HttpResponseContent;
-  headers?: HttpHeaders;
-  query?: HttpParams;
-}
 
 /**
  * Defines the abstract base request. It provides a common object that should be extended
  * when we need to create a request.
  */
-export abstract class AbstractRequest implements RequestInterface, CloneableInterface {
+export abstract class AbstractRequest implements RequestInterface {
 
   /**
    * The path of the request.
@@ -58,7 +47,15 @@ export abstract class AbstractRequest implements RequestInterface, CloneableInte
    */
   readonly responseType: HttpResponseContent = HttpResponseContent.JSON;
 
-  constructor(init: RequestInit) {
+  constructor(init: {
+    path: string;
+    version: string | null;
+    method?: HttpMethod;
+    withCredentials?: boolean;
+    responseType?: HttpResponseContent;
+    headers?: HttpHeaders;
+    query?: HttpParams;
+  }) {
     this._path = init.path;
     this._version = init.version;
     this.method = init.method || HttpMethod.GET;
@@ -109,7 +106,13 @@ export abstract class AbstractRequest implements RequestInterface, CloneableInte
   /**
    * @inheritDoc
    */
-  clone(update?: RequestUpdate): RequestInterface & CloneableInterface {
+  clone(update?: {
+    method?: HttpMethod;
+    withCredentials?: boolean;
+    responseType?: HttpResponseContent;
+    headers?: HttpHeaders;
+    query?: HttpParams;
+  }): RequestInterface {
     if (!update) {
       return Reflect.construct(this.constructor, [ {
         path: this._path,

--- a/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
+++ b/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
@@ -42,20 +42,20 @@ import { TestRequestHandler } from '../fixtures/test.request-handler';
     const classMapHandler = new MessageMapper(collection, extractor, this.classResolverMock.object);
 
     const errorExecutionBusMiddleware = new ErrorExecutionBusMiddleware(this.loggerMock.object);
-    const requestHandlerBusMiddleware = new RequestHandlerBusMiddleware(classMapHandler);
     const requestExecutionBusMiddleware = new RequestExecutionBusMiddleware(this.httpAdapterMock.object);
+    const requestHandlerBusMiddleware = new RequestHandlerBusMiddleware(classMapHandler);
 
     const messageBus = new MessageBus([
       errorExecutionBusMiddleware,
+      requestExecutionBusMiddleware,
       requestHandlerBusMiddleware,
-      requestExecutionBusMiddleware
     ]);
 
     this.requestExecutor = new RequestExecutor(
       'baseHost',
       null,
       0,
-      60,
+      0,
       messageBus
     );
   }
@@ -108,7 +108,7 @@ import { TestRequestHandler } from '../fixtures/test.request-handler';
     this.classResolverMock
       .setup(x => x.resolve(TestRequestHandler))
       .returns(() => new TestRequestHandler())
-      .verifiable(Times.once());
+      .verifiable(Times.never());
 
     this.httpAdapterMock
       .setup(x => x.execute('baseHost', request))

--- a/packages/http/tests/unit/http-execution.unit.tests.ts
+++ b/packages/http/tests/unit/http-execution.unit.tests.ts
@@ -1,0 +1,109 @@
+
+import { JsonType } from '@layerr/core';
+import { suite, test, Mock, should } from '@layerr/test';
+import { HttpExecution, RequestInterface, RemoteResponse } from '../..';
+
+@suite class HttpExecutionUnitTests {
+
+  @test 'should create the http execution with all data'() {
+
+    const requestMock = Mock.ofType<RequestInterface>();
+    const responseMock = Mock.ofType<RemoteResponse<JsonType>>();
+
+    const execution = new HttpExecution({
+      request: requestMock.object,
+      response: responseMock.object,
+      content: {},
+      baseHost: 'baseHost',
+      retryAttemptCount: 0,
+      retryDelay: 0,
+      timeout: 0
+    });
+
+    should.equal(execution.request, requestMock.object);
+    should.equal(execution.response, responseMock.object);
+    execution.baseHost.should.be.eql('baseHost');
+    execution.retryAttemptCount.should.be.eql(0);
+    execution.retryDelay.should.be.eql(0);
+    execution.timeout.should.be.eql(0);
+
+    execution.hasResponse().should.be.true;
+    execution.hasContent().should.be.true;
+  }
+
+  @test 'should create the http execution with mandatory data'() {
+
+    const requestMock = Mock.ofType<RequestInterface>();
+    const responseMock = Mock.ofType<RemoteResponse<JsonType>>();
+
+    const execution = new HttpExecution({
+      request: requestMock.object,
+      baseHost: 'baseHost',
+      retryAttemptCount: 0,
+      retryDelay: 0,
+      timeout: 0
+    });
+
+    should.equal(execution.request, requestMock.object);
+    should.not.equal(execution.response, responseMock.object);
+    execution.baseHost.should.be.eql('baseHost');
+    execution.retryAttemptCount.should.be.eql(0);
+    execution.retryDelay.should.be.eql(0);
+    execution.timeout.should.be.eql(0);
+
+    execution.hasResponse().should.be.false;
+    execution.hasContent().should.be.false;
+  }
+
+  @test 'should clone the http execution'() {
+
+    const requestMock = Mock.ofType<RequestInterface>();
+    const responseMock = Mock.ofType<RemoteResponse<JsonType>>();
+
+    let execution = new HttpExecution({
+      request: requestMock.object,
+      baseHost: 'baseHost',
+      retryAttemptCount: 0,
+      retryDelay: 0,
+      timeout: 0
+    });
+
+    should.equal(execution.request, requestMock.object);
+    should.not.equal(execution.response, responseMock.object);
+    execution.baseHost.should.be.eql('baseHost');
+    execution.retryAttemptCount.should.be.eql(0);
+    execution.retryDelay.should.be.eql(0);
+    execution.timeout.should.be.eql(0);
+
+    execution.hasResponse().should.be.false;
+    execution.hasContent().should.be.false;
+
+    execution = execution.clone();
+
+    should.equal(execution.request, requestMock.object);
+    should.not.equal(execution.response, responseMock.object);
+    execution.baseHost.should.be.eql('baseHost');
+    execution.retryAttemptCount.should.be.eql(0);
+    execution.retryDelay.should.be.eql(0);
+    execution.timeout.should.be.eql(0);
+
+    execution.hasResponse().should.be.false;
+    execution.hasContent().should.be.false;
+
+    execution = execution.clone({
+      response: responseMock.object,
+      content: {},
+    });
+
+    should.equal(execution.request, requestMock.object);
+    should.equal(execution.response, responseMock.object);
+    execution.baseHost.should.be.eql('baseHost');
+    execution.retryAttemptCount.should.be.eql(0);
+    execution.retryDelay.should.be.eql(0);
+    execution.timeout.should.be.eql(0);
+
+    execution.hasResponse().should.be.true;
+    execution.hasContent().should.be.true;
+  }
+
+}

--- a/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
@@ -21,13 +21,18 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the timeout'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const timeoutError = new TimeoutError();
     timeoutError.message = 'timeout';
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(timeoutError))
@@ -55,8 +60,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 400'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -70,7 +80,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))
@@ -100,8 +110,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 401'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -115,7 +130,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))
@@ -145,8 +160,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 403'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -160,7 +180,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))
@@ -190,8 +210,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 404'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -205,7 +230,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))
@@ -235,8 +260,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 500'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -250,7 +280,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))
@@ -280,8 +310,13 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
 
   @test 'should create an error for the error status 0'() {
 
-    const execution = new HttpExecution();
-    execution.request = {} as unknown as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     const baseError = new Error();
 
@@ -295,7 +330,7 @@ import { ErrorRemoteResponse } from '../../../src/response/error-remote-response
       'url'
     );
 
-    const nextMock = Mock.ofType<(message: HttpExecution) => Observable<any>>();
+    const nextMock = Mock.ofType<(message: HttpExecution<any>) => Observable<any>>();
     nextMock
       .setup(x => x(execution))
       .returns(() => throwError(errorRemoteResponse))

--- a/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
@@ -33,8 +33,13 @@ import { TestRequest } from '../../fixtures/test.request';
 
   @test 'should resolve the correct base host'(done) {
 
-    const execution = new HttpExecution();
-    execution.request = {} as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     this.extractorMock
       .setup(x => x.extract(execution.request))
@@ -46,11 +51,11 @@ import { TestRequest } from '../../fixtures/test.request';
       .returns(() => 'ADMIN')
       .verifiable(Times.once());
 
-    const next = (message: HttpExecution) => of(message);
+    const next = (message: HttpExecution<any>) => of(message);
 
     return this.middleware.handle(execution, next)
       .subscribe(
-        (message: HttpExecution) => {
+        (message: HttpExecution<any>) => {
 
           message.baseHost.should.be.eql('api.admin');
 
@@ -64,8 +69,13 @@ import { TestRequest } from '../../fixtures/test.request';
 
   @test 'should throw an exception if the backend key is not defined'(done) {
 
-    const execution = new HttpExecution();
-    execution.request = {} as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     this.extractorMock
       .setup(x => x.extract(execution.request))
@@ -77,7 +87,7 @@ import { TestRequest } from '../../fixtures/test.request';
       .returns(() => 'NOT_DEFINED')
       .verifiable(Times.once());
 
-    const next = (message: HttpExecution) => of(message);
+    const next = (message: HttpExecution<any>) => of(message);
 
     return this.middleware.handle(execution, next)
       .subscribe(
@@ -103,8 +113,13 @@ import { TestRequest } from '../../fixtures/test.request';
 
   @test 'should throw an exception if the base host is not defined'(done) {
 
-    const execution = new HttpExecution();
-    execution.request = {} as RequestInterface;
+    const execution = new HttpExecution<any>({
+      request: {} as unknown as RequestInterface,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
     this.extractorMock
       .setup(x => x.extract(execution.request))
@@ -116,7 +131,7 @@ import { TestRequest } from '../../fixtures/test.request';
       .returns(() => 'NULL')
       .verifiable(Times.once());
 
-    const next = (message: HttpExecution) => of(message);
+    const next = (message: HttpExecution<any>) => of(message);
 
     return this.middleware.handle(execution, next)
       .subscribe(

--- a/packages/http/tests/unit/middleware/request-handler.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/request-handler.bus-middleware.unit.tests.ts
@@ -1,87 +1,157 @@
 
 import { MessageMapperInterface } from '@layerr/bus';
 import { JsonType } from '@layerr/core';
-import { suite, test, Mock, IMock, Times } from '@layerr/test';
+import { suite, test, Mock, IMock, Times, It, should } from '@layerr/test';
 import { of } from 'rxjs';
-import { RequestInterface } from '../../..';
+import { RequestInterface, HttpLayerrError } from '../../..';
 import { HttpExecution } from '../../../src/http-execution';
 import { RequestHandlerBusMiddleware } from '../../../src/middleware/request-handler.bus-middleware';
 import { RemoteResponse } from '../../../src/response/remote-response';
 
 @suite class RequestHandlerBusMiddlewareUnitTests {
 
-  private middeware: RequestHandlerBusMiddleware;
+  private middleware: RequestHandlerBusMiddleware;
   private messageMapperMock: IMock<MessageMapperInterface>;
 
   before() {
     this.messageMapperMock = Mock.ofType<MessageMapperInterface>();
-    this.middeware = new RequestHandlerBusMiddleware(this.messageMapperMock.object);
+    this.middleware = new RequestHandlerBusMiddleware(this.messageMapperMock.object);
   }
 
   @test 'should call the handler'() {
 
-    const request = {} as unknown as RequestInterface;
-    const response = {} as unknown as RemoteResponse<JsonType>;
+    const requestMock = Mock.ofType<RequestInterface>();
+    const responseMock = Mock.ofType<RemoteResponse<JsonType>>();
 
-    const execution = new HttpExecution();
-    execution.request = request;
-    execution.response = response;
+    const execution = new HttpExecution<any>({
+      request: requestMock.object,
+      response: responseMock.object,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
-    const next = (message: HttpExecution) => of(message);
+    const next = (message: HttpExecution<any>) => of(message);
 
     const handlerMock = Mock.ofType<Function>();
     handlerMock
-      .setup(x => x(request, response))
-      .returns(() => of(response))
+      .setup(x => x(
+        It.is((request: RequestInterface) => {
+          should.equal(request, requestMock.object);
+          return true;
+        }),
+        It.is((response: RemoteResponse<JsonType>) => {
+          should.equal(response, responseMock.object);
+          return true;
+        })
+      ))
+      .returns(() => of({ body: 'body' }))
       .verifiable(Times.once());
 
     this.messageMapperMock
-      .setup(x => x.getHandlers(request))
+      .setup(x => x.getHandlers(It.is((request: RequestInterface) => {
+        should.equal(request, requestMock.object);
+        return true;
+      })))
       .returns(() => [ handlerMock.object ])
       .verifiable(Times.once());
 
-    return this.middeware.handle(execution, next)
+    return this.middleware.handle(execution, next)
       .subscribe(
-        (message: HttpExecution) => {
-          message.should.be.eql(execution);
+        (message: HttpExecution<any>) => {
+
+          message.should.not.be.eql(execution);
+          message.should.not.be.equal(execution);
 
           handlerMock.verifyAll();
           this.messageMapperMock.verifyAll();
+
+          requestMock.verifyAll();
+          responseMock.verifyAll();
         }
       );
   }
 
   @test 'should call the next middleware if no handlers are defined'() {
 
-    const request = {} as unknown as RequestInterface;
-    const response = {} as unknown as RemoteResponse<JsonType>;
+    const requestMock = Mock.ofType<RequestInterface>();
+    const responseMock = Mock.ofType<RemoteResponse<JsonType>>();
 
-    const execution = new HttpExecution();
-    execution.request = request;
-    execution.response = response;
+    const execution = new HttpExecution<any>({
+      request: requestMock.object,
+      response: responseMock.object,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
 
-    const next = (message: HttpExecution) => of(message);
+    const next = (message: HttpExecution<any>) => of(message);
 
     const handlerMock = Mock.ofType<Function>();
     handlerMock
-      .setup(x => x(request, response))
-      .returns(() => of(response))
+      .setup(x => x(
+        It.is((request: RequestInterface) => {
+          should.equal(request, requestMock.object);
+          return true;
+        }),
+        It.is((response: RemoteResponse<JsonType>) => {
+          should.equal(response, responseMock.object);
+          return true;
+        })
+      ))
+      .returns(() => of({ body: 'body' }))
       .verifiable(Times.never());
 
     this.messageMapperMock
-      .setup(x => x.getHandlers(request))
+      .setup(x => x.getHandlers(It.is((request: RequestInterface) => {
+        should.equal(request, requestMock.object);
+        return true;
+      })))
       .returns(() => [])
       .verifiable(Times.once());
 
-    return this.middeware.handle(execution, next)
+    return this.middleware.handle(execution, next)
       .subscribe(
-        (message: HttpExecution) => {
+        (message: HttpExecution<any>) => {
           message.should.be.eql(execution);
 
           handlerMock.verifyAll();
           this.messageMapperMock.verifyAll();
+
+          requestMock.verifyAll();
+          responseMock.verifyAll();
         }
       );
+  }
+
+  @test 'should return an error if the response is not defined'() {
+
+    const requestMock = Mock.ofType<RequestInterface>();
+
+    const execution = new HttpExecution<any>({
+      request: requestMock.object,
+      baseHost: 'baseHost',
+      retryDelay: 200,
+      retryAttemptCount: null,
+      timeout: 6000
+    });
+
+    const next = (message: HttpExecution<any>) => of(message);
+
+    const handlerMock = Mock.ofType<Function>();
+    handlerMock
+      .setup(x => x(It.isAny(), It.isAny()))
+      .verifiable(Times.never());
+
+    this.messageMapperMock
+      .setup(x => x.getHandlers(It.isAny()))
+      .verifiable(Times.once());
+
+    (() => {
+      this.middleware.handle(execution, next);
+    }).should.throw(HttpLayerrError);
   }
 
 }


### PR DESCRIPTION
Make the request immutable to create a new request once we want to modify it.

BREAKING CHANGE: Changed the HttpExecution to specify a generic for the content. Make it immutable,
you need to clone it to modify it. Added the content property that will be now returned by the
executor. The content property is filled by the handler middleware based on the return type of the
request handler. Now, it should return the content instead of the remote response.

fix #59