### PR TITLE
refactor(all): add a tsconfig to the tests directories

### DIFF
--- a/packages/bus/tests/tsconfig.json
+++ b/packages/bus/tests/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "strict": false,
+    "noUnusedLocals": false,
+    "paths": {
+      "@layerr/test": [
+        "../../../tests/index.ts"
+      ]
+    }
+  },
+  "exclude": [
+    "../node_modules"
+  ],
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "strict": false,
+    "noUnusedLocals": false,
+    "paths": {
+      "@layerr/test": [
+        "../../../tests/index.ts"
+      ]
+    }
+  },
+  "exclude": [
+    "../node_modules"
+  ],
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/packages/http/src/middleware/request-handler.bus-middleware.ts
+++ b/packages/http/src/middleware/request-handler.bus-middleware.ts
@@ -1,7 +1,8 @@
 import { MessageMapperInterface, MessageBusMiddlewareInterface } from '@layerr/bus';
 import { Observable } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
-import { HttpLayerrError, HttpLayerrErrorType } from '../..';
+import { HttpLayerrErrorType } from '../error/http-layerr.error-type';
+import { HttpLayerrError } from '../error/http-layerr.error';
 import { HttpExecution } from '../http-execution';
 
 /**

--- a/packages/http/tests/tsconfig.json
+++ b/packages/http/tests/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "isolatedModules": false,
+    "strict": false,
+    "noUnusedLocals": false,
+    "paths": {
+      "@layerr/test": [
+        "../../../tests/index.ts"
+      ]
+    }
+  },
+  "exclude": [
+    "../node_modules"
+  ],
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
We want to add a tsconfig specific for the tests so that the IDE will stop to mark the test classes
as unused.

fix #69