### PR TITLE
fix(http): missing request in the clone parameters execution method

### DIFF
--- a/packages/http/src/http-execution.ts
+++ b/packages/http/src/http-execution.ts
@@ -80,6 +80,7 @@ export class HttpExecution<T> {
    */
   clone(update?: {
     baseHost?: string;
+    request?: RequestInterface;
     response?: RemoteResponse<JsonType>;
     content?: T | null;
   }): HttpExecution<T> {
@@ -97,7 +98,7 @@ export class HttpExecution<T> {
     }
 
     return new HttpExecution<T>({
-      request: this.request,
+      request: update.request || this.request,
       baseHost: update.baseHost || this.baseHost,
       retryAttemptCount: this.retryAttemptCount,
       retryDelay: this.retryDelay,

--- a/packages/http/tests/fixtures/test.request-handler.ts
+++ b/packages/http/tests/fixtures/test.request-handler.ts
@@ -1,8 +1,8 @@
 
 import { JsonType } from '@layerr/core';
 import { Observable, of } from 'rxjs';
-import { RequestInterface } from '../..';
 import { RequestHandlerInterface } from '../../src/request-handler/request-handler.interface';
+import { RequestInterface } from '../../src/request/request.interface';
 import { RemoteResponse } from '../../src/response/remote-response';
 
 export class TestRequestHandler implements RequestHandlerInterface {

--- a/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
+++ b/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
@@ -8,7 +8,6 @@ import {
 } from '@layerr/bus';
 import { ClassResolverInterface, JsonType, LoggerInterface } from '@layerr/core';
 import { of, throwError } from 'rxjs';
-import { HttpHeaders } from '../..';
 import { HttpAdapterInterface } from '../../src/adapter/http-adapter.interface';
 import { HttpLayerrError } from '../../src/error/http-layerr.error';
 import { HttpLayerrErrorType } from '../../src/error/http-layerr.error-type';
@@ -18,6 +17,7 @@ import { RequestHandlerBusMiddleware } from '../../src/middleware/request-handle
 import { ErrorRemoteResponse } from '../../src/response/error-remote-response';
 import { RemoteResponse } from '../../src/response/remote-response';
 import { RequestExecutor } from '../../src/service/request-executor';
+import { HttpHeaders } from '../../src/utilities/http-headers';
 import { TestRequest } from '../fixtures/test.request';
 import { TestRequestHandler } from '../fixtures/test.request-handler';
 

--- a/packages/http/tests/unit/http-execution.unit.tests.ts
+++ b/packages/http/tests/unit/http-execution.unit.tests.ts
@@ -1,7 +1,9 @@
 
 import { JsonType } from '@layerr/core';
 import { suite, test, Mock, should } from '@layerr/test';
-import { HttpExecution, RequestInterface, RemoteResponse } from '../..';
+import { HttpExecution } from '../../src/http-execution';
+import { RequestInterface } from '../../src/request/request.interface';
+import { RemoteResponse } from '../../src/response/remote-response';
 
 @suite class HttpExecutionUnitTests {
 
@@ -90,12 +92,15 @@ import { HttpExecution, RequestInterface, RemoteResponse } from '../..';
     execution.hasResponse().should.be.false;
     execution.hasContent().should.be.false;
 
+    const newRequestMock = Mock.ofType<RequestInterface>();
+
     execution = execution.clone({
       response: responseMock.object,
+      request: newRequestMock.object,
       content: {},
     });
 
-    should.equal(execution.request, requestMock.object);
+    should.equal(execution.request, newRequestMock.object);
     should.equal(execution.response, responseMock.object);
     execution.baseHost.should.be.eql('baseHost');
     execution.retryAttemptCount.should.be.eql(0);

--- a/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/error-execution.bus-middleware.unit.tests.ts
@@ -2,12 +2,13 @@
 import { LoggerInterface } from '@layerr/core';
 import { suite, test, IMock, Mock, Times, should } from '@layerr/test';
 import { Observable, throwError, TimeoutError } from 'rxjs';
-import { RequestInterface, HttpHeaders } from '../../..';
 import { HttpLayerrError } from '../../../src/error/http-layerr.error';
 import { HttpLayerrErrorType } from '../../../src/error/http-layerr.error-type';
 import { HttpExecution } from '../../../src/http-execution';
 import { ErrorExecutionBusMiddleware } from '../../../src/middleware/error-execution.bus-middleware';
+import { RequestInterface } from '../../../src/request/request.interface';
 import { ErrorRemoteResponse } from '../../../src/response/error-remote-response';
+import { HttpHeaders } from '../../../src/utilities/http-headers';
 
 @suite class ErrorExecutionBusMiddlewareUnitTests {
 

--- a/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/http-backend.bus-middleware.unit.tests.ts
@@ -2,12 +2,12 @@
 import { MessageTypeExtractorInterface } from '@layerr/bus';
 import { suite, test, IMock, Mock, Times, should } from '@layerr/test';
 import { of } from 'rxjs';
-import { RequestInterface } from '../../..';
 import { HttpLayerrError } from '../../../src/error/http-layerr.error';
 import { HttpLayerrErrorType } from '../../../src/error/http-layerr.error-type';
 import { HttpExecution } from '../../../src/http-execution';
 import { HttpBackendDecoratorResolver } from '../../../src/middleware/http-backend/decorator/http-backend.decorator-resolver';
 import { HttpBackendBusMiddleware } from '../../../src/middleware/http-backend/http-backend.bus-middleware';
+import { RequestInterface } from '../../../src/request/request.interface';
 import { TestRequest } from '../../fixtures/test.request';
 
 @suite class HttpBackendBusMiddlewareUnitTests {

--- a/packages/http/tests/unit/middleware/request-handler.bus-middleware.unit.tests.ts
+++ b/packages/http/tests/unit/middleware/request-handler.bus-middleware.unit.tests.ts
@@ -3,9 +3,10 @@ import { MessageMapperInterface } from '@layerr/bus';
 import { JsonType } from '@layerr/core';
 import { suite, test, Mock, IMock, Times, It, should } from '@layerr/test';
 import { of } from 'rxjs';
-import { RequestInterface, HttpLayerrError } from '../../..';
+import { HttpLayerrError } from '../../../src/error/http-layerr.error';
 import { HttpExecution } from '../../../src/http-execution';
 import { RequestHandlerBusMiddleware } from '../../../src/middleware/request-handler.bus-middleware';
+import { RequestInterface } from '../../../src/request/request.interface';
 import { RemoteResponse } from '../../../src/response/remote-response';
 
 @suite class RequestHandlerBusMiddlewareUnitTests {

--- a/packages/http/tests/unit/service/request-executor.unit.tests.ts
+++ b/packages/http/tests/unit/service/request-executor.unit.tests.ts
@@ -2,8 +2,8 @@
 import { MessageBus } from '@layerr/bus';
 import { suite, test, IMock, Mock, It, Times, should } from '@layerr/test';
 import { of } from 'rxjs';
-import { RequestInterface } from '../../..';
 import { HttpExecution } from '../../../src/http-execution';
+import { RequestInterface } from '../../../src/request/request.interface';
 import { RequestExecutor } from '../../../src/service/request-executor';
 
 @suite class RequestExecutorUnitTests {

--- a/packages/http/tests/unit/utilities/http-params.unit.tests.ts
+++ b/packages/http/tests/unit/utilities/http-params.unit.tests.ts
@@ -1,6 +1,5 @@
 
 import { suite, test, should } from '@layerr/test';
-import { HttpHeaders } from '../../..';
 import { HttpParams } from '../../../src/utilities/http-params';
 
 @suite class HttpParamsUnitTests {


### PR DESCRIPTION
We miss adding the request to the HttpExecution object.

fix #71