### PR TITLE
fix(http): add body to the init and update object of the request

### DIFF
--- a/packages/http/src/request/abstract.request.ts
+++ b/packages/http/src/request/abstract.request.ts
@@ -10,7 +10,7 @@ import { RequestInterface } from './request.interface';
  * Defines the abstract base request. It provides a common object that should be extended
  * when we need to create a request.
  */
-export abstract class AbstractRequest implements RequestInterface {
+export abstract class AbstractRequest<T> implements RequestInterface {
 
   /**
    * The path of the request.
@@ -31,6 +31,11 @@ export abstract class AbstractRequest implements RequestInterface {
    * The query of the request.
    */
   private _query: HttpParams = new HttpParams();
+
+  /**
+   * The body of the request.
+   */
+  private _body?: T;
 
   /**
    * @inheritDoc
@@ -55,6 +60,7 @@ export abstract class AbstractRequest implements RequestInterface {
     responseType?: HttpResponseContent;
     headers?: HttpHeaders;
     query?: HttpParams;
+    body?: T;
   }) {
     this._path = init.path;
     this._version = init.version;
@@ -63,6 +69,7 @@ export abstract class AbstractRequest implements RequestInterface {
     this.responseType = init.responseType || HttpResponseContent.JSON;
     this._headers = init.headers || new HttpHeaders();
     this._query = init.query || new HttpParams();
+    this._body = init.body || undefined;
   }
 
   /**
@@ -100,7 +107,8 @@ export abstract class AbstractRequest implements RequestInterface {
    * @inheritDoc
    */
   getBody(): JsonType | null {
-    return null;
+    // This ensures a pure object body.
+    return this._body ? JSON.parse(JSON.stringify(this._body)) : null;
   }
 
   /**
@@ -112,6 +120,7 @@ export abstract class AbstractRequest implements RequestInterface {
     responseType?: HttpResponseContent;
     headers?: HttpHeaders;
     query?: HttpParams;
+    body?: T;
   }): RequestInterface {
     if (!update) {
       return Reflect.construct(this.constructor, [ {
@@ -122,6 +131,7 @@ export abstract class AbstractRequest implements RequestInterface {
         responseType: this.responseType,
         headers: this._headers,
         query: this._query,
+        body: this._body
       } ]);
     }
 
@@ -133,6 +143,7 @@ export abstract class AbstractRequest implements RequestInterface {
       responseType: update.responseType || this.responseType,
       headers: update.headers || this._headers,
       query: update.query || this._query,
+      body: update.body || this._body
     } ]);
   }
 }

--- a/packages/http/tests/fixtures/test.request.ts
+++ b/packages/http/tests/fixtures/test.request.ts
@@ -1,4 +1,4 @@
 
 import { AbstractRequest } from '../../src/request/abstract.request';
 
-export class TestRequest extends AbstractRequest {}
+export class TestRequest extends AbstractRequest<any> {}

--- a/packages/http/tests/unit/request/abstract-request.unit.tests.ts
+++ b/packages/http/tests/unit/request/abstract-request.unit.tests.ts
@@ -3,10 +3,16 @@ import { suite, should } from '@layerr/test';
 import { AbstractRequest } from '../../../src/request/abstract.request';
 import { TestRequest } from '../../fixtures/test.request';
 
+interface RequestBody {
+  username: string;
+  password: string;
+}
+
 @suite class AbstractRestfulRequestUnitTests {
 
-  private requestWithVersion: AbstractRequest;
-  private requestNoVersion: AbstractRequest;
+  private requestWithVersion: AbstractRequest<RequestBody>;
+  private requestNoVersion: AbstractRequest<RequestBody>;
+  private requestWithBody: AbstractRequest<RequestBody>;
 
   before() {
     this.requestWithVersion = new TestRequest({
@@ -16,6 +22,14 @@ import { TestRequest } from '../../fixtures/test.request';
     this.requestNoVersion = new TestRequest({
       path: '/path',
       version: null
+    });
+    this.requestWithBody = new TestRequest({
+      path: '/path',
+      version: 'v1',
+      body: {
+        username: 'user',
+        password: 'pass'
+      }
     });
   }
 
@@ -40,21 +54,30 @@ import { TestRequest } from '../../fixtures/test.request';
     this.requestWithVersion.getQuery().should.not.be.null;
   }
 
+  @test 'should serialize the body'() {
+    this.requestWithBody.getBody().should.be.eql({ username: 'user', password: 'pass' });
+  }
+
   @test 'should clone the request'() {
-    const clonedRequest = this.requestWithVersion.clone();
+    const clonedRequest = this.requestWithBody.clone();
     clonedRequest.path.should.be.eql(this.requestWithVersion.path);
     clonedRequest.version.should.be.eql(this.requestWithVersion.version);
 
-    let headers = this.requestWithVersion.getHeaders();
+    let headers = this.requestWithBody.getHeaders();
     headers = headers.append('name', 'value');
-    const headersRequest = this.requestWithVersion.clone({ headers });
+    const headersRequest = this.requestWithBody.clone({ headers });
     headersRequest.path.should.be.eql('/v1/path');
     headersRequest.version.should.be.eql('v1');
     headersRequest.getHeaders().should.be.eql(headers);
 
-    const headersRequest1 = this.requestWithVersion.clone({});
+    const headersRequest1 = this.requestWithBody.clone({});
     headersRequest1.path.should.be.eql('/v1/path');
     headersRequest1.version.should.be.eql('v1');
+
+    const bodyRequest1 = this.requestWithBody.clone({ body: { username: 'user1', password: 'pass1' } });
+    bodyRequest1.path.should.be.eql('/v1/path');
+    bodyRequest1.version.should.be.eql('v1');
+    bodyRequest1.getBody().should.be.eql({ username: 'user1', password: 'pass1' });
   }
 
 }


### PR DESCRIPTION
We need to add the body in the init and update of the request object in order to support the clone
ability.

fix #73