### PR TITLE
fix(http): unable to correctly clone the request

### DIFF
--- a/packages/http/src/utilities/http-headers.ts
+++ b/packages/http/src/utilities/http-headers.ts
@@ -1,4 +1,7 @@
 
+// Defines the http headers init type.
+export declare type HttpHeadersInit = HttpHeaders | string[][] | Record<string, string>;
+
 interface HttpHeadersUpdate {
   name: string;
   value?: string;
@@ -15,7 +18,7 @@ export class HttpHeaders implements Headers {
    */
   private _map: Map<string, string>;
 
-  constructor(headers?: HttpHeaders | string[][] | Record<string, string>) {
+  constructor(headers?: HttpHeadersInit) {
 
     this._map = new Map();
 

--- a/packages/http/src/utilities/http-params.ts
+++ b/packages/http/src/utilities/http-params.ts
@@ -1,4 +1,7 @@
 
+// Defines the http params init type.
+export declare type HttpParamsInit = HttpParams | string[][] | Record<string, string>;
+
 interface HttpParamsUpdate {
   name: string;
   value?: string;
@@ -15,27 +18,27 @@ export class HttpParams implements URLSearchParams {
    */
   private _map: Map<string, string> = new Map();
 
-  constructor(headers?: HttpParams | string[][] | Record<string, string>) {
+  constructor(params?: HttpParamsInit) {
 
     this._map = new Map();
 
-    if (!headers) {
+    if (!params) {
       return;
     }
 
-    if (Array.isArray(headers)) {
-      this._map = new Map(headers as unknown as readonly [ string, string ][]);
+    if (Array.isArray(params)) {
+      this._map = new Map(params as unknown as readonly [ string, string ][]);
       return;
     }
 
-    if (headers instanceof HttpParams) {
-      headers.forEach(
+    if (params instanceof HttpParams) {
+      params.forEach(
         (value: string, key: string) => this._map.set(key, value)
       );
       return;
     }
 
-    const headersInit = headers as Record<string, string>;
+    const headersInit = params as Record<string, string>;
     Object.keys(headersInit).forEach((key: string) => this._map.set(key, (headersInit[key])));
   }
 

--- a/packages/http/tests/fixtures/login.request.ts
+++ b/packages/http/tests/fixtures/login.request.ts
@@ -1,0 +1,24 @@
+
+import { JsonType } from '@layerr/core';
+import { AbstractRequest } from '../../src/request/abstract.request';
+
+export class LoginRequest extends AbstractRequest {
+
+  constructor(
+    private readonly username: string,
+    private readonly password: string,
+  ) {
+    super({
+      path: '/login',
+      version: 'v1'
+    });
+  }
+
+  getBody(): JsonType | null {
+    return {
+      username: this.username,
+      password: this.password
+    };
+  }
+
+}

--- a/packages/http/tests/fixtures/test.request.ts
+++ b/packages/http/tests/fixtures/test.request.ts
@@ -1,4 +1,4 @@
 
 import { AbstractRequest } from '../../src/request/abstract.request';
 
-export class TestRequest extends AbstractRequest<any> {}
+export class TestRequest extends AbstractRequest {}

--- a/packages/http/tests/integration/login-request.integration.tests.ts
+++ b/packages/http/tests/integration/login-request.integration.tests.ts
@@ -1,0 +1,30 @@
+
+import { suite } from '@layerr/test';
+import { LoginRequest } from '../fixtures/login.request';
+
+@suite class LoginRequestIntegrationTests {
+
+  private loginRequest: LoginRequest;
+
+  before() {
+    this.loginRequest = new LoginRequest('user', 'pass');
+  }
+
+  @test 'should create the request for the login'() {
+    this.loginRequest.getBody().username.should.be.eql('user');
+    this.loginRequest.getBody().password.should.be.eql('pass');
+  }
+
+  @test 'should clone the request for the login'() {
+    const request = this.loginRequest.clone({ query: { param: 'param' } });
+
+    request.getQuery().has('param').should.be.true;
+    request.getQuery().get('param').should.be.eql('param');
+
+    request.getBody().username.should.be.eql('user');
+    request.getBody().password.should.be.eql('pass');
+
+    request.should.be.instanceof(LoginRequest);
+  }
+
+}

--- a/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
+++ b/packages/http/tests/integration/request-executor-single-backend.service.integration.tests.ts
@@ -1,5 +1,5 @@
 
-import { suite, test, IMock, Mock, Times } from '@layerr/test';
+import { suite, test, IMock, Mock, Times, It } from '@layerr/test';
 import {
   CollectionHandlerLookup,
   FunctionConstructorMessageTypeExtractor,
@@ -21,7 +21,7 @@ import { HttpHeaders } from '../../src/utilities/http-headers';
 import { TestRequest } from '../fixtures/test.request';
 import { TestRequestHandler } from '../fixtures/test.request-handler';
 
-@suite class RequestExecutorIntegrationTests {
+@suite class RequestExecutorSingleBackendServiceIntegrationTests {
 
   private requestExecutor: RequestExecutor;
   private classResolverMock: IMock<ClassResolverInterface>;
@@ -77,7 +77,13 @@ import { TestRequestHandler } from '../fixtures/test.request-handler';
       .verifiable(Times.once());
 
     this.httpAdapterMock
-      .setup(x => x.execute('baseHost', request))
+      .setup(x => x.execute(
+        'baseHost',
+        It.is((param: TestRequest) => {
+          param.should.be.eql(request);
+          return true;
+        })
+      ))
       .returns(() => of(remoteResponse))
       .verifiable(Times.once());
 
@@ -111,7 +117,13 @@ import { TestRequestHandler } from '../fixtures/test.request-handler';
       .verifiable(Times.never());
 
     this.httpAdapterMock
-      .setup(x => x.execute('baseHost', request))
+      .setup(x => x.execute(
+        'baseHost',
+        It.is((param: TestRequest) => {
+          param.should.be.eql(request);
+          return true;
+        })
+      ))
       .returns(() => throwError(errorRemoteResponse))
       .verifiable(Times.once());
 

--- a/packages/http/tests/unit/request/abstract-request.unit.tests.ts
+++ b/packages/http/tests/unit/request/abstract-request.unit.tests.ts
@@ -1,18 +1,14 @@
 
 import { suite, should } from '@layerr/test';
 import { AbstractRequest } from '../../../src/request/abstract.request';
+import { HttpHeaders } from '../../../src/utilities/http-headers';
+import { HttpParams } from '../../../src/utilities/http-params';
 import { TestRequest } from '../../fixtures/test.request';
-
-interface RequestBody {
-  username: string;
-  password: string;
-}
 
 @suite class AbstractRestfulRequestUnitTests {
 
-  private requestWithVersion: AbstractRequest<RequestBody>;
-  private requestNoVersion: AbstractRequest<RequestBody>;
-  private requestWithBody: AbstractRequest<RequestBody>;
+  private requestWithVersion: AbstractRequest;
+  private requestNoVersion: AbstractRequest;
 
   before() {
     this.requestWithVersion = new TestRequest({
@@ -21,14 +17,12 @@ interface RequestBody {
     });
     this.requestNoVersion = new TestRequest({
       path: '/path',
-      version: null
-    });
-    this.requestWithBody = new TestRequest({
-      path: '/path',
-      version: 'v1',
-      body: {
-        username: 'user',
-        password: 'pass'
+      version: null,
+      headers: {
+        header: 'header'
+      },
+      query: {
+        query: 'query'
       }
     });
   }
@@ -48,36 +42,29 @@ interface RequestBody {
 
   @test 'should return an empty headers map'() {
     this.requestWithVersion.getHeaders().should.not.be.null;
+    this.requestNoVersion.getHeaders().should.be.eql(new HttpHeaders({ header: 'header' }));
   }
 
   @test 'should return an empty query map'() {
     this.requestWithVersion.getQuery().should.not.be.null;
-  }
-
-  @test 'should serialize the body'() {
-    this.requestWithBody.getBody().should.be.eql({ username: 'user', password: 'pass' });
+    this.requestNoVersion.getQuery().should.be.eql(new HttpParams({ query: 'query' }));
   }
 
   @test 'should clone the request'() {
-    const clonedRequest = this.requestWithBody.clone();
+    const clonedRequest = this.requestWithVersion.clone();
     clonedRequest.path.should.be.eql(this.requestWithVersion.path);
     clonedRequest.version.should.be.eql(this.requestWithVersion.version);
 
-    let headers = this.requestWithBody.getHeaders();
+    let headers = this.requestWithVersion.getHeaders();
     headers = headers.append('name', 'value');
-    const headersRequest = this.requestWithBody.clone({ headers });
+    const headersRequest = this.requestWithVersion.clone({ headers });
     headersRequest.path.should.be.eql('/v1/path');
     headersRequest.version.should.be.eql('v1');
     headersRequest.getHeaders().should.be.eql(headers);
 
-    const headersRequest1 = this.requestWithBody.clone({});
+    const headersRequest1 = this.requestWithVersion.clone({});
     headersRequest1.path.should.be.eql('/v1/path');
     headersRequest1.version.should.be.eql('v1');
-
-    const bodyRequest1 = this.requestWithBody.clone({ body: { username: 'user1', password: 'pass1' } });
-    bodyRequest1.path.should.be.eql('/v1/path');
-    bodyRequest1.version.should.be.eql('v1');
-    bodyRequest1.getBody().should.be.eql({ username: 'user1', password: 'pass1' });
   }
 
 }


### PR DESCRIPTION
Due to the cloning strategy, the request body can't be cloned. We changed the cloning strategy to
allow correctly to create a copy of the object.

fix #75