### PR TITLE
fix(http): headers are not cloned

### DIFF
--- a/packages/http/src/request/abstract.request.ts
+++ b/packages/http/src/request/abstract.request.ts
@@ -122,8 +122,8 @@ export abstract class AbstractRequest implements RequestInterface {
     // Clones the object.
     const clone = Object.create(this);
 
-    clone['_headers'] = update ? new HttpHeaders(update.headers || this.getHeaders()) : new HttpHeaders();
-    clone['_query'] = update ? new HttpParams(update.query || this.getQuery()) : new HttpParams();
+    clone['_headers'] = update ? new HttpHeaders(update.headers || this.getHeaders()) : this.getHeaders();
+    clone['_query'] = update ? new HttpParams(update.query || this.getQuery()) : this.getQuery();
 
     return clone;
   }

--- a/packages/http/tests/unit/request/abstract-request.unit.tests.ts
+++ b/packages/http/tests/unit/request/abstract-request.unit.tests.ts
@@ -55,6 +55,10 @@ import { TestRequest } from '../../fixtures/test.request';
     clonedRequest.path.should.be.eql(this.requestWithVersion.path);
     clonedRequest.version.should.be.eql(this.requestWithVersion.version);
 
+    const clonedRequestNoVersion = this.requestNoVersion.clone();
+    clonedRequestNoVersion.getHeaders().should.be.eql(new HttpHeaders({ header: 'header' }));
+    clonedRequestNoVersion.getQuery().should.be.eql(new HttpParams({ query: 'query' }));
+
     let headers = this.requestWithVersion.getHeaders();
     headers = headers.append('name', 'value');
     const headersRequest = this.requestWithVersion.clone({ headers });


### PR DESCRIPTION
Headers and params are not correctly cloned when there are no updates.

fix #77