### PR TITLE
feat(http): allow to handle url parameters

### DIFF
--- a/packages/http/src/request/abstract.request.ts
+++ b/packages/http/src/request/abstract.request.ts
@@ -10,6 +10,7 @@ import { RequestInterface } from './request.interface';
  * Defines the basic type of the request updates.
  */
 export interface RequestUpdate {
+  path?: string;
   method?: HttpMethod;
   withCredentials?: boolean;
   responseType?: HttpResponseContent;
@@ -121,7 +122,11 @@ export abstract class AbstractRequest implements RequestInterface {
 
     // Clones the object.
     const clone = Object.create(this);
-    
+
+    clone['_path'] = update ? update.path || this._path : this._path;
+    clone['method'] = update ? update.method || this.method : this.method;
+    clone['withCredentials'] = update ? update.withCredentials || this.withCredentials : this.withCredentials;
+    clone['responseType'] = update ? update.responseType || this.responseType : this.responseType;
     clone['_headers'] = update ? new HttpHeaders(update.headers || this.getHeaders()) : this.getHeaders();
     clone['_query'] = update ? new HttpParams(update.query || this.getQuery()) : this.getQuery();
 

--- a/packages/http/tests/unit/request/abstract-request.unit.tests.ts
+++ b/packages/http/tests/unit/request/abstract-request.unit.tests.ts
@@ -1,8 +1,9 @@
-
 import { suite, should } from '@layerr/test';
 import { AbstractRequest } from '../../../src/request/abstract.request';
 import { HttpHeaders } from '../../../src/utilities/http-headers';
+import { HttpMethod } from '../../../src/utilities/http-method';
 import { HttpParams } from '../../../src/utilities/http-params';
+import { HttpResponseContent } from '../../../src/utilities/http-response-content';
 import { TestRequest } from '../../fixtures/test.request';
 
 @suite class AbstractRestfulRequestUnitTests {
@@ -54,6 +55,11 @@ import { TestRequest } from '../../fixtures/test.request';
     const clonedRequest = this.requestWithVersion.clone();
     clonedRequest.path.should.be.eql(this.requestWithVersion.path);
     clonedRequest.version.should.be.eql(this.requestWithVersion.version);
+    clonedRequest.method.should.be.eql(this.requestWithVersion.method);
+    clonedRequest.withCredentials.should.be.eql(this.requestWithVersion.withCredentials);
+    clonedRequest.responseType.should.be.eql(this.requestWithVersion.responseType);
+    clonedRequest.getHeaders().should.be.eql(this.requestWithVersion.getHeaders());
+    clonedRequest.getQuery().should.be.eql(this.requestWithVersion.getQuery());
 
     const clonedRequestNoVersion = this.requestNoVersion.clone();
     clonedRequestNoVersion.getHeaders().should.be.eql(new HttpHeaders({ header: 'header' }));
@@ -69,6 +75,32 @@ import { TestRequest } from '../../fixtures/test.request';
     const headersRequest1 = this.requestWithVersion.clone({});
     headersRequest1.path.should.be.eql('/v1/path');
     headersRequest1.version.should.be.eql('v1');
+  }
+
+  @test 'should clone the request with information'() {
+
+    let headers = this.requestWithVersion.getHeaders();
+    headers = headers.append('name', 'value');
+
+    let query = this.requestWithVersion.getQuery();
+    query = query.append('name', 'value');
+
+    const clonedRequest = this.requestWithVersion.clone({
+      path: '/newPath',
+      method: HttpMethod.DELETE,
+      withCredentials: false,
+      responseType: HttpResponseContent.TEXT,
+      headers,
+      query
+    });
+
+    clonedRequest.path.should.be.eql('/v1/newPath');
+    clonedRequest.version.should.be.eql('v1');
+    clonedRequest.method.should.be.eql(HttpMethod.DELETE);
+    clonedRequest.withCredentials.should.be.false;
+    clonedRequest.responseType.should.be.eql(HttpResponseContent.TEXT);
+    clonedRequest.getHeaders().should.be.eql(headers);
+    clonedRequest.getQuery().should.be.eql(query);
   }
 
 }


### PR DESCRIPTION
We want to support a path where we have some URL parameters. These params are similar to the query,
but they are embedded in the path when a consumer gets it.

fix #79