### PR TITLE
fix(http): change the name of the parameter for the request handler i…

### DIFF
--- a/packages/http/src/adapter/http-adapter.interface.ts
+++ b/packages/http/src/adapter/http-adapter.interface.ts
@@ -12,6 +12,6 @@ export interface HttpAdapterInterface {
   /**
    * Executes the call using the specific adapter.
    */
-  execute<T>(baseHost: string, remoteCall: RequestInterface): Observable<RemoteResponse<T>>;
+  execute<T>(baseHost: string, request: RequestInterface): Observable<RemoteResponse<T>>;
 
 }

--- a/packages/http/src/middleware/error-execution.bus-middleware.ts
+++ b/packages/http/src/middleware/error-execution.bus-middleware.ts
@@ -28,7 +28,7 @@ export class ErrorExecutionBusMiddleware implements MessageBusMiddlewareInterfac
           let rethrownError = error;
 
           if (error instanceof TimeoutError) {
-            this._logger.error(`TimeoutError: ${error.message} - RemoteCall: ${message.request.path}`);
+            this._logger.error(`TimeoutError: ${error.message} - Request: ${message.request.path}`);
             rethrownError = new HttpLayerrError(
               error.message,
               HttpLayerrErrorType.TIMEOUT,
@@ -45,7 +45,7 @@ export class ErrorExecutionBusMiddleware implements MessageBusMiddlewareInterfac
             const isUnknown = !error.status || error.status === 0;
 
             if (isUnknown) {
-              this._logger.error(`Unknown error: ${error.message} - RemoteCall: ${message.request.path}`);
+              this._logger.error(`Unknown error: ${error.message} - Request: ${message.request.path}`);
               rethrownError = new HttpLayerrError(
                 `No status code - Unknown error [ ${error.statusText} - ${error.message} ]`,
                 HttpLayerrErrorType.UNKNOWN,
@@ -75,7 +75,7 @@ export class ErrorExecutionBusMiddleware implements MessageBusMiddlewareInterfac
                   type = HttpLayerrErrorType.UNEXPECTED;
               }
 
-              this._logger.error(`Error: ${error.status} ${error.statusText} ${error.message} - RemoteCall: ${message.request.path}`);
+              this._logger.error(`Error: ${error.status} ${error.statusText} ${error.message} - Request: ${message.request.path}`);
               rethrownError = new HttpLayerrError(
                 `${error.statusText ? error.statusText : 'Generic error'} - ${error.message}`,
                 type,

--- a/packages/http/src/request-handler/request-handler.interface.ts
+++ b/packages/http/src/request-handler/request-handler.interface.ts
@@ -13,6 +13,6 @@ export interface RequestHandlerInterface {
   /**
    * Handles a specific remote call.
    */
-  handle(remoteCall: RequestInterface, response: RemoteResponse<JsonType>): Observable<any>;
+  handle(request: RequestInterface, response: RemoteResponse<JsonType>): Observable<any>;
 
 }

--- a/packages/http/tests/fixtures/test.request-handler.ts
+++ b/packages/http/tests/fixtures/test.request-handler.ts
@@ -6,7 +6,7 @@ import { RequestInterface } from '../../src/request/request.interface';
 import { RemoteResponse } from '../../src/response/remote-response';
 
 export class TestRequestHandler implements RequestHandlerInterface {
-  handle(_remoteCall: RequestInterface, response: RemoteResponse<JsonType>): Observable<RemoteResponse<JsonType>> {
+  handle(_request: RequestInterface, response: RemoteResponse<JsonType>): Observable<RemoteResponse<JsonType>> {
     return of(response);
   }
 


### PR DESCRIPTION
…nterface

Right now the params name in the request handler interface refers to the old fashion naming we had.

fix #87