### PR TITLE
feat(http): add support for the append in params object

### DIFF
--- a/packages/http/tests/unit/utilities/http-params.unit.tests.ts
+++ b/packages/http/tests/unit/utilities/http-params.unit.tests.ts
@@ -147,4 +147,18 @@ import { HttpParams } from '../../../src/utilities/http-params';
 
   }
 
+  @test 'should append data to the same entry'() {
+
+    let params = this.params.set('name', 'value1');
+    params = params.append('name2', 'value1');
+    params = params.append('name', 'value2');
+    params = params.set('name1', undefined);
+    params = params.append('name1', undefined);
+
+    params.toObject().should.be.eql({
+      name: 'value1,value2',
+      name2: 'value1'
+    });
+  }
+
 }


### PR DESCRIPTION
We want to update the HttpParams to support append method in order to create a query string with
multiple values for the same entry.

fix #86