### PR TITLE
refactor(all): move the dependencies as peer dependencies

### DIFF
--- a/docs/bus/1-installation/README.md
+++ b/docs/bus/1-installation/README.md
@@ -2,9 +2,9 @@
 Install from the NPM repository using **npm** or **yarn**:
 
 ```
-npm install @layerr/bus
+npm install @layerr/core @layerr/bus rxjs reflect-metadata
 ```
 
 ```
-yarn add @layerr/bus
+yarn add @layerr/core @layerr/bus rxjs reflect-metadata
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "reflect-metadata": "^0.1.13",
-    "rxjs": "~6.5.5",
+    "rxjs": "^6.5.5",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/bus/README.md
+++ b/packages/bus/README.md
@@ -12,12 +12,12 @@ comfortable with it, don't worry, you can use promise-like async code.
 Use [npm](https://www.npmjs.com/) package manager to install it.
 
 ```bash
-npm install @layerr/bus
+npm install @layerr/core @layerr/bus rxjs reflect-metadata
 ```
 
 Use [yarn](https://yarnpkg.com/) package manager to install it.
 ```bash
-yarn add @layerr/bus
+yarn add @layerr/core @layerr/bus rxjs reflect-metadata
 ```
 
 ## Documentation

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -13,12 +13,12 @@ comfortable with it, don't worry, you can use promise-like async code.
 Use [npm](https://www.npmjs.com/) package manager to install it.
 
 ```bash
-npm install @layerr/http
+npm install @layerr/core @layerr/bus @layerr/http rxjs reflect-metadata
 ```
 
 Use [yarn](https://yarnpkg.com/) package manager to install it.
 ```bash
-yarn add @layerr/http
+yarn add @layerr/core @layerr/bus @layerr/http rxjs reflect-metadata
 ```
 
 ## Documentation

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -9,12 +9,12 @@ It uses [RxJS](https://github.com/ReactiveX/RxJS) as internal engine.
 Use [npm](https://www.npmjs.com/) package manager to install it.
 
 ```bash
-npm install @layerr/state
+npm install @layerr/state rxjs
 ```
 
 Use [yarn](https://yarnpkg.com/) package manager to install it.
 ```bash
-yarn add @layerr/state
+yarn add @layerr/state rxjs
 ```
 
 ## Documentation

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@layerr/state",
+  "version": "0.0.0",
+  "description": "A powerful library to create a state management layer in your application",
+  "author": "Matteo Tafani Alunno <matteo.tafanialunno@gmail.com>",
+  "homepage": "https://github.com/tafax/layerr/tree/master/packages/state#readme",
+  "license": "MIT"
+}

--- a/workspace.json
+++ b/workspace.json
@@ -29,7 +29,8 @@
             "tsConfig": "packages/bus/tsconfig.lib.json",
             "packageJson": "packages/bus/package.json",
             "main": "packages/bus/src/index.ts",
-            "assets": ["packages/bus/*.md", "LICENSE"]
+            "assets": ["packages/bus/*.md", "LICENSE"],
+            "buildableProjectDepsInPackageJsonType": "peerDependencies"
           }
         },
         "release": {
@@ -69,7 +70,8 @@
             "tsConfig": "packages/core/tsconfig.lib.json",
             "packageJson": "packages/core/package.json",
             "main": "packages/core/src/index.ts",
-            "assets": ["packages/core/*.md", "LICENSE"]
+            "assets": ["packages/core/*.md", "LICENSE"],
+            "buildableProjectDepsInPackageJsonType": "peerDependencies"
           }
         },
         "release": {
@@ -109,7 +111,8 @@
             "tsConfig": "packages/http/tsconfig.lib.json",
             "packageJson": "packages/http/package.json",
             "main": "packages/http/src/index.ts",
-            "assets": ["packages/http/*.md", "LICENSE"]
+            "assets": ["packages/http/*.md", "LICENSE"],
+            "buildableProjectDepsInPackageJsonType": "peerDependencies"
           }
         },
         "release": {
@@ -149,7 +152,8 @@
             "tsConfig": "packages/state/tsconfig.lib.json",
             "packageJson": "packages/state/package.json",
             "main": "packages/state/src/index.ts",
-            "assets": ["packages/state/*.md", "LICENSE"]
+            "assets": ["packages/state/*.md", "LICENSE"],
+            "buildableProjectDepsInPackageJsonType": "peerDependencies"
           }
         },
         "release": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7275,17 +7275,10 @@ rxjs-for-await@0.0.2:
   resolved "https://registry.yarnpkg.com/rxjs-for-await/-/rxjs-for-await-0.0.2.tgz#26598a1d6167147cc192172970e7eed4e620384b"
   integrity sha512-IJ8R/ZCFMHOcDIqoABs82jal00VrZx8Xkgfe7TOKoaRPAW5nH/VFlG23bXpeGdrmtqI9UobFPgUKgCuFc7Lncw==
 
-rxjs@^6.4.0, rxjs@^6.5.4:
+rxjs@^6.4.0, rxjs@^6.5.4, rxjs@^6.5.5:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@~6.5.5:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Moving the dependencies as peer dependencies to avoid incompatibility for the consumers

BREAKING CHANGE: Now you have to installa manually the dependencies for the libraries

fix #108