### PR TITLE
feat(http): add ability to specify the request content type

### DIFF
--- a/packages/http/src/lib/request/abstract.request.ts
+++ b/packages/http/src/lib/request/abstract.request.ts
@@ -2,6 +2,7 @@ import { JsonType } from '@layerr/core';
 import { HttpHeaders } from '../utilities/http-headers';
 import { HttpMethod } from '../utilities/http-method';
 import { HttpParams } from '../utilities/http-params';
+import { HttpRequestContent } from '../utilities/http-request-content';
 import { HttpResponseContent } from '../utilities/http-response-content';
 import { RequestInterface, RequestUpdate } from './request.interface';
 
@@ -27,6 +28,11 @@ export abstract class AbstractRequest implements RequestInterface {
    * @inheritDoc
    */
   public readonly withCredentials: boolean = false;
+
+  /**
+   * @inheritDoc
+   */
+  public readonly contentType: HttpRequestContent = HttpRequestContent.APPLICATION_JSON;
 
   /**
    * @inheritDoc
@@ -58,6 +64,7 @@ export abstract class AbstractRequest implements RequestInterface {
     this._version = init.version;
     this.method = init.method || HttpMethod.GET;
     this.withCredentials = init.withCredentials || false;
+    this.contentType = init.contentType || HttpRequestContent.APPLICATION_JSON;
     this.responseType = init.responseType || HttpResponseContent.JSON;
     this._headers = init.headers ? new HttpHeaders(init.headers) : new HttpHeaders();
     this._query = init.query ? new HttpParams(init.query) : new HttpParams();
@@ -118,6 +125,7 @@ export abstract class AbstractRequest implements RequestInterface {
 
     clone['_path'] = update ? update.rawPath || update.path || this._path : this._path;
     clone['method'] = update ? update.method || this.method : this.method;
+    clone['contentType'] = update ? update.contentType || this.contentType : this.contentType;
     clone['withCredentials'] = update ? update.withCredentials || this.withCredentials : this.withCredentials;
     clone['responseType'] = update ? update.responseType || this.responseType : this.responseType;
     clone['_headers'] = update ? new HttpHeaders(update.headers || this.getHeaders()) : this.getHeaders();

--- a/packages/http/src/lib/request/request.interface.ts
+++ b/packages/http/src/lib/request/request.interface.ts
@@ -2,71 +2,78 @@ import { JsonType } from '@layerr/core';
 import { HttpHeaders, HttpHeadersInit } from '../utilities/http-headers';
 import { HttpMethod } from '../utilities/http-method';
 import { HttpParams, HttpParamsInit } from '../utilities/http-params';
+import { HttpRequestContent } from '../utilities/http-request-content';
 import { HttpResponseContent } from '../utilities/http-response-content';
 
 /**
- * Defines the basic type of the request updates.
+ * Defines the basic type of the request updates
  */
 export interface RequestUpdate {
   path?: string;
   rawPath?: string;
   method?: HttpMethod;
   withCredentials?: boolean;
+  contentType?: HttpRequestContent;
   responseType?: HttpResponseContent;
   headers?: HttpHeadersInit;
   query?: HttpParamsInit;
 }
 
 /**
- * Defines the interface for the actions.
- * It exposes the needed properties to create a request.
+ * Defines the interface for the actions
+ * It exposes the needed properties to create a request
  * Each class that implements the interface should provide
- * this info in order to allow the bus to create the correct request.
+ * this info in order to allow the bus to create the correct request
  */
 export interface RequestInterface {
 
   /**
-   * The version to the endpoint.
+   * The version to the endpoint
    */
   version: string | null;
 
   /**
-   * The path to the endpoint.
+   * The path to the endpoint
    */
   path: string;
 
   /**
-   * The HTTP method of the request.
+   * The HTTP method of the request
    */
   method: HttpMethod;
 
   /**
-   * A flag that tells if the credentials should be sent over the CORS.
+   * A flag that tells if the credentials should be sent over the CORS
    */
   withCredentials: boolean;
 
   /**
-   * The declared response type.
+   * The request content type to use
+   */
+  contentType: HttpRequestContent;
+
+  /**
+   * The declared response type
    */
   responseType: HttpResponseContent;
 
   /**
-   * The headers of the request.
+   * The headers of the request
    */
   getHeaders(): HttpHeaders;
 
   /**
-   * The query parameters of the request.
+   * The query parameters of the request
    */
   getQuery(): HttpParams;
 
   /**
-   * The body of the request.
+   * The body of the request
    */
   getBody(): JsonType | null;
 
   /**
-   * Clones the current request.
+   * Clones the current request
    */
   clone(update?: RequestUpdate): RequestInterface;
 }

--- a/packages/http/src/lib/utilities/http-request-content.ts
+++ b/packages/http/src/lib/utilities/http-request-content.ts
@@ -1,0 +1,7 @@
+/**
+ * The HTTP request content type
+ */
+export enum HttpRequestContent {
+  APPLICATION_JSON = 'application/json',
+  MULTIPART_FORM_DATA = 'multipart/form-data',
+}

--- a/packages/http/test/unit/middleware/decorator/http-backend.decorator-resolver.unit.test.ts
+++ b/packages/http/test/unit/middleware/decorator/http-backend.decorator-resolver.unit.test.ts
@@ -6,6 +6,7 @@ import { JsonType } from '../../../../../core/src/lib/utilities/json-type';
 import { HttpHeaders } from '../../../../src/lib/utilities/http-headers';
 import { HttpMethod } from '../../../../src/lib/utilities/http-method';
 import { HttpParams } from '../../../../src/lib/utilities/http-params';
+import { HttpRequestContent } from '../../../../src/lib/utilities/http-request-content';
 import { HttpResponseContent } from '../../../../src/lib/utilities/http-response-content';
 
 @HttpBackend('BACKEND')
@@ -14,6 +15,7 @@ class Message implements RequestInterface {
   public path: string;
   public method: HttpMethod;
   public withCredentials: boolean;
+  public contentType: HttpRequestContent;
   public responseType: HttpResponseContent;
   getHeaders(): HttpHeaders {
     throw new Error('Method not implemented.');
@@ -31,7 +33,7 @@ class Message implements RequestInterface {
 
 @suite
 class HttpBackendDecoratorResolverUnitTest {
-  
+
   private SUT: HttpBackendDecoratorResolver<unknown>;
 
   before() {

--- a/packages/http/test/unit/request/abstract-request.unit.test.ts
+++ b/packages/http/test/unit/request/abstract-request.unit.test.ts
@@ -2,6 +2,7 @@ import { suite, test } from '@testdeck/jest';
 import { HttpHeaders } from '../../../src/lib/utilities/http-headers';
 import { HttpMethod } from '../../../src/lib/utilities/http-method';
 import { HttpParams } from '../../../src/lib/utilities/http-params';
+import { HttpRequestContent } from '../../../src/lib/utilities/http-request-content';
 import { HttpResponseContent } from '../../../src/lib/utilities/http-response-content';
 import { TestRequest } from '../../fixtures/test.request';
 
@@ -92,6 +93,7 @@ class AbstractRestfulRequestUnitTests {
     expect(clonedRequest.path).toBe(request.path);
     expect(clonedRequest.version).toBe(request.version);
     expect(clonedRequest.method).toBe(request.method);
+    expect(clonedRequest.contentType).toBe(request.contentType);
     expect(clonedRequest.withCredentials).toBe(request.withCredentials);
     expect(clonedRequest.responseType).toBe(request.responseType);
     expect(clonedRequest.getHeaders()).toStrictEqual(request.getHeaders());
@@ -124,6 +126,7 @@ class AbstractRestfulRequestUnitTests {
       path: '/newPath',
       method: HttpMethod.DELETE,
       withCredentials: false,
+      contentType: HttpRequestContent.MULTIPART_FORM_DATA,
       responseType: HttpResponseContent.TEXT,
       headers: request.getHeaders().append('name', 'value'),
       query: request.getQuery().append('name', 'value'),
@@ -133,6 +136,7 @@ class AbstractRestfulRequestUnitTests {
     expect(clonedRequest.version).toBe('v1');
     expect(clonedRequest.method).toBe(HttpMethod.DELETE);
     expect(clonedRequest.withCredentials).toBeFalsy();
+    expect(clonedRequest.contentType).toBe(HttpRequestContent.MULTIPART_FORM_DATA);
     expect(clonedRequest.responseType).toBe(HttpResponseContent.TEXT);
     expect(clonedRequest.getHeaders()).toStrictEqual(request.getHeaders().append('name', 'value'));
     expect(clonedRequest.getQuery()).toStrictEqual(request.getQuery().append('name', 'value'));


### PR DESCRIPTION
Adding the request content type to handle different type of request content

BREAKING CHANGE: Adding a new property in the RequestInterface to handle the content type. Any class
that inherits from it should adapt itself.

#110